### PR TITLE
chore: update findable-ui to latest version v28.0.0 (#84)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ncpi-dataset-catalog",
       "version": "0.3.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^27.0.0",
+        "@databiosphere/findable-ui": "^28.0.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mdx-js/loader": "^3.0.1",
@@ -2490,9 +2490,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-27.0.0.tgz",
-      "integrity": "sha512-i6LU03iwpnMaQpx8LTxn2/Xj8hakCF3HupVIa35kDIhxbgSWXpKNfsZTrpV8oiKbXpY57v0l/DXfQm9B4pgMJQ==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-28.0.0.tgz",
+      "integrity": "sha512-fVKxTP3nPEmMjLkwCnLLmhF+5Zs2bfTP3dJRph4qwidpDNeCbLw9k2I2by5bZADrcqOQo0vMSaIxn0ZKtngAvQ==",
       "engines": {
         "node": "20.10.0"
       },
@@ -27365,9 +27365,9 @@
       "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw=="
     },
     "@databiosphere/findable-ui": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-27.0.0.tgz",
-      "integrity": "sha512-i6LU03iwpnMaQpx8LTxn2/Xj8hakCF3HupVIa35kDIhxbgSWXpKNfsZTrpV8oiKbXpY57v0l/DXfQm9B4pgMJQ==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-28.0.0.tgz",
+      "integrity": "sha512-fVKxTP3nPEmMjLkwCnLLmhF+5Zs2bfTP3dJRph4qwidpDNeCbLw9k2I2by5bZADrcqOQo0vMSaIxn0ZKtngAvQ==",
       "requires": {}
     },
     "@digitak/esrun": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update-all-ncpi-sources": "npm run update-crdc-source && npm run update-bdc-source && npm run update-anvil-source && npm run update-kfdrc-source"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^27.0.0",
+    "@databiosphere/findable-ui": "^28.0.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
### Ticket

Closes #84.

### Reviewers

@NoopDog.

### Changes

- Updated `findable-ui` to latest version `v28.0.0`.
- Fixes filtering while in chart view.

This pull request updates a dependency in the `package.json` file to ensure compatibility with the latest features and fixes.

Dependency update:

* Updated `@databiosphere/findable-ui` from version `^27.0.0` to `^28.0.0` to incorporate the latest improvements and bug fixes.