### PR TITLE
feat: use temp login in scripts (#142)

### DIFF
--- a/cc-prod-ncpi-catalog-deploy.sh
+++ b/cc-prod-ncpi-catalog-deploy.sh
@@ -14,5 +14,5 @@ npm run build:prod
 export BUCKET=s3://bhy-ncpi-data.org
 export SRCDIR=out/
 
-aws s3 sync  $SRCDIR $BUCKET --delete  --profile excira
-aws cloudfront create-invalidation --distribution-id ENV5LQ3SY9LXL --paths "/*" --profile excira
+aws s3 sync  $SRCDIR $BUCKET --delete  --profile ncpi-prod-deployer
+aws cloudfront create-invalidation --distribution-id ENV5LQ3SY9LXL --paths "/*" --profile ncpi-prod-deployer


### PR DESCRIPTION
This pull request updates the deployment script to use a different AWS profile for production deployments. The change ensures that the correct credentials are used when syncing files to S3 and invalidating the CloudFront cache.

Deployment configuration update:

* Updated `cc-prod-ncpi-catalog-deploy.sh` to use the `ncpi-prod-deployer` AWS profile instead of `excira` for both S3 sync and CloudFront invalidation commands.### Ticket

