### PR TITLE
fix: add dbGapUrl to CSV-built catalog studies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ Thumbs.db
 # IDEs and editors
 .idea
 /.vscode
+.obsidian
 
 # hygen
 _templates

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,6 @@ analytics
 
 # catalog data
 catalog
+
+# catalog build scripts and source data
+catalog-build

--- a/catalog-build/build-platform-studies.ts
+++ b/catalog-build/build-platform-studies.ts
@@ -48,6 +48,7 @@ export async function buildNCPIPlatformStudies(
     const ncpiStudy = {
       ...study,
       consentLongNames,
+      dbGapUrl: `https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=${study.studyAccession}`,
       duosUrl: duosUrlByDbGapId.get(study.dbGapId) ?? null,
       platforms: [stub.platform],
     };


### PR DESCRIPTION
## Summary
- Adds missing `dbGapUrl` field to the CSV-based platform study builder, fixing `getStaticProps` serialization errors in dev mode
- Adds `.obsidian/` to `.gitignore` (IDE config folder)
- Adds `catalog-build/` to `.prettierignore` (build scripts excluded from app-level formatting)

Closes #155

## Test plan
- [ ] Run `npm run dev` and click a study detail page — should no longer throw serialization error
- [ ] Verify `dbGapUrl` appears in generated catalog JSON after `npm run build-ncpi-db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)