### PR TITLE
feat: up-arrow recalls previous query in chat input

### DIFF
--- a/app/components/Chat/chat.tsx
+++ b/app/components/Chat/chat.tsx
@@ -118,7 +118,7 @@ export const Chat = (): JSX.Element => {
     if (!query || loading) return;
 
     setInput("");
-    setQueryHistory((prev) => [...prev, query]);
+    setQueryHistory((prev) => [...prev, query].slice(-50));
     historyIndexRef.current = -1;
     draftRef.current = "";
     setMessages((prev) => [...prev, { text: query, type: "user" }]);
@@ -192,7 +192,11 @@ export const Chat = (): JSX.Element => {
           historyIndexRef.current -= 1;
         }
         setInput(queryHistory[historyIndexRef.current]);
-      } else if (e.key === "ArrowDown" && historyIndexRef.current >= 0) {
+      } else if (
+        e.key === "ArrowDown" &&
+        historyIndexRef.current >= 0 &&
+        cursorAtStart
+      ) {
         e.preventDefault();
         if (historyIndexRef.current < queryHistory.length - 1) {
           historyIndexRef.current += 1;


### PR DESCRIPTION
## Summary
- Adds shell-style up/down arrow query history navigation to the chat search input
- Pressing up arrow when the input is empty (or cursor is at position 0) cycles back through previously submitted queries
- Down arrow cycles forward; past the newest entry restores the in-progress draft
- Multiline editing is unaffected — history navigation only triggers at cursor start

## Test plan
- [ ] Submit several queries in the chat UI
- [ ] Press up arrow in empty input — should recall the most recent query
- [ ] Press up arrow repeatedly — should cycle through older queries
- [ ] Press down arrow — should cycle forward, then restore empty input
- [ ] Type a partial query, press up arrow, then down past newest — should restore the partial draft
- [ ] Enter a multiline query (Shift+Enter), use arrow keys within it — should navigate normally without triggering history

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)