### PR TITLE
chore: remove unused Google Sign-In script

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,13 +6,8 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          {/* TODO render script for enableAuthorization only.
-           Using async defer would cause intermittent errors loding the gsi client script.
-            using beforeInteractive did work but there may be a bug that is fixed
-          an a later version. */}
           {/* TODO self host fonts */}
           {/* TODO only load fonts required for the app being built */}
-          <script src="https://accounts.google.com/gsi/client" defer></script>
           <link rel="stylesheet" href="https://use.typekit.net/qhb0geh.css" />
           <link
             href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Roboto+Mono&display=swap"


### PR DESCRIPTION
## Ticket
- Closes #205.

## Summary
- Removes unused Google Identity Services script (`accounts.google.com/gsi/client`) from `_document.tsx`
- Eliminates Content Security Policy violations in production
- The script was loaded but never used (no authorization feature was implemented)

Closes #205

## Test plan
- [ ] Verify build completes successfully
- [ ] Confirm no CSP errors in browser console

🤖 Generated with [Claude Code](https://claude.ai/claude-code)