### PR TITLE
fix: override ai.url in prod config to use prod backend

### DIFF
--- a/site-config/ncpi-catalog/prod/config.ts
+++ b/site-config/ncpi-catalog/prod/config.ts
@@ -3,6 +3,8 @@ import devConfig from "../dev/config";
 
 const config: SiteConfig = {
   ...devConfig,
+  // Ternary required: devConfig.ai is typed as AiConfig | undefined,
+  // so TS needs the guard to narrow before spreading.
   ai: devConfig.ai
     ? {
         ...devConfig.ai,


### PR DESCRIPTION
## Summary
- Prod frontend was hitting the **dev** backend for AI search queries because `ai.url` was inherited from devConfig via `...devConfig` spread
- Override `ai.url` in prod config to point to the prod App Runner backend (`prejcyhpmp...`)
- The old `app/components/Chat/` that used `NEXT_PUBLIC_SEARCH_API_URL` env var is dead code — findable-ui's `ResearchView` reads `ai.url` from site config

Fixes #222

## Test plan
- [ ] Deploy to prod and verify AI search queries hit `prejcyhpmp.us-east-1.awsapprunner.com` (not `ffbijgxxf2`)
- [ ] Verify search results render correctly on `ncpi-data.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)