### PR TITLE
fix: link variable study column to local study detail page

### DIFF
--- a/app/views/ResearchView/components/Main/components/Results/components/QueryResults/variable/columns.ts
+++ b/app/views/ResearchView/components/Main/components/Results/components/QueryResults/variable/columns.ts
@@ -21,7 +21,7 @@ const DESCRIPTION: ColumnDef<Variable> = {
   accessorKey: "description",
   header: "Description",
   id: "description",
-  meta: { width: { max: "1fr", min: "140px" } },
+  meta: { width: { max: "3fr", min: "200px" } },
 };
 
 const STUDY_TITLE: ColumnDef<Variable> = {
@@ -36,7 +36,7 @@ const VARIABLE_NAME: ColumnDef<Variable> = {
   accessorKey: "variableName",
   header: "Variable Name",
   id: "variableName",
-  meta: { width: { max: "2fr", min: "160px" } },
+  meta: { width: { max: "1fr", min: "140px" } },
 };
 
 export const COLUMNS: ColumnDef<Variable>[] = [

--- a/app/views/ResearchView/components/Main/components/Results/components/QueryResults/variable/viewBuilder.ts
+++ b/app/views/ResearchView/components/Main/components/Results/components/QueryResults/variable/viewBuilder.ts
@@ -2,6 +2,7 @@ import * as C from "../../../../../../../../../components";
 import { CellContext } from "@tanstack/react-table";
 import { JSX } from "react";
 import { Variable } from "../../../types/variable";
+import { ROUTES } from "../../../../../../../../../../routes/constants";
 
 /**
  * Builds props for the dbGapUrl Link component.
@@ -27,6 +28,6 @@ export const renderStudyTitle = (
 ): JSX.Element => {
   return C.Link({
     label: ctx.row.original.studyTitle ?? ctx.row.original.studyId,
-    url: ctx.row.original.studyUrl,
+    url: `${ROUTES.RESEARCH_STUDIES}/${ctx.row.original.studyId}`,
   });
 };


### PR DESCRIPTION
## Summary

- Variable results table "Study" column now links to the local study detail page instead of external dbGaP URL, matching study results table behavior
- Rebalanced column widths: Description gets 3fr (was 1fr) for one-line descriptions; Variable Name reduced to 1fr (was 2fr)

Closes #251

## Test plan

- [ ] Run a research query that returns variables
- [ ] Verify "Study" column links navigate to `/research/studies/{studyId}` (local detail page)
- [ ] Verify description column is wider and variable name column is narrower

🤖 Generated with [Claude Code](https://claude.com/claude-code)