### PR TITLE
Update search placeholder text

### DIFF
--- a/app/views/HomeView/components/Main/components/HeroSection/components/SearchPrompt/searchPrompt.tsx
+++ b/app/views/HomeView/components/Main/components/HeroSection/components/SearchPrompt/searchPrompt.tsx
@@ -32,7 +32,7 @@ export const SearchPrompt = (): JSX.Element => {
         });
       }}
     >
-      <Input placeholder="Ask anything..." />
+      <Input placeholder="Search for studies or variables" />
       <StyledStack spacing={2} useFlexGap>
         <StyledChips message={PROMPT_MESSAGE} />
         <StyledChip

--- a/e2e/chat-ui.spec.ts
+++ b/e2e/chat-ui.spec.ts
@@ -53,7 +53,7 @@ test.describe("Chat UI", () => {
 
     await expect(input).toHaveAttribute(
       "placeholder",
-      "Ask about studies or variables"
+      "Search for studies or variables"
     );
 
     await submitQuery(page, "diabetes studies on AnVIL");

--- a/site-config/ncpi-catalog/dev/config.ts
+++ b/site-config/ncpi-catalog/dev/config.ts
@@ -28,7 +28,7 @@ const config: SiteConfig = {
   ai: {
     enabled: true,
     prompt: {
-      inputPlaceholder: "Ask about studies or variables",
+      inputPlaceholder: "Search for studies or variables",
       suggestions: [
         {
           label: "Smoking + BMI in heart disease",


### PR DESCRIPTION
## Summary
- Update placeholder text on home page and research page inputs to "Search for studies or variables"
- Update e2e test assertion to match

Closes #302

## Test plan
- [ ] Verify home page input shows "Search for studies or variables"
- [ ] Verify research page input shows "Search for studies or variables"
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)