### PR TITLE
Fix KFDRC homepage suggestion query

### DIFF
--- a/app/views/HomeView/components/Main/components/HeroSection/components/SearchPrompt/constants.ts
+++ b/app/views/HomeView/components/Main/components/HeroSection/components/SearchPrompt/constants.ts
@@ -13,8 +13,8 @@ export const PROMPT_MESSAGE = {
       query: "Diabetes studies with whole genome sequencing",
     },
     {
-      label: "Pediatric cancer on KFDRC",
-      query: "Pediatric cancer on KFDRC",
+      label: "Studies about cancer on KFDRC",
+      query: "Studies about cancer on KFDRC",
     },
     {
       label: "All variables measuring chocolate consumption",


### PR DESCRIPTION
## Summary
- Change KFDRC homepage chip query from "Pediatric cancer on KFDRC" to "Studies about cancer on KFDRC" which returns results

Closes #302

## Test plan
- [ ] Click the KFDRC chip on the home page and verify results are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)