### PR TITLE
feat: ensure About page follows standard findable-ui text layout (#304)

### DIFF
--- a/app/components/Layout/components/Content/content.styles.ts
+++ b/app/components/Layout/components/Content/content.styles.ts
@@ -1,8 +1,8 @@
-import { ThemeProps } from "@databiosphere/findable-ui/lib/theme/types";
 import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font";
+import { typographyToCSS } from "@databiosphere/findable-ui/lib/styles/common/mixins/typography";
+import { ThemeProps } from "@databiosphere/findable-ui/lib/theme/types";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { typographyToCSS } from "@databiosphere/findable-ui/lib/styles/common/mixins/typography";
 
 const muiAlert = ({ theme }: ThemeProps) => css`
   .MuiAlert-root {
@@ -24,6 +24,19 @@ const muiAlert = ({ theme }: ThemeProps) => css`
       .MuiAlertTitle-root {
         ${css(theme.typography["heading-small"])};
       }
+
+      ol > li,
+      ul > li {
+        margin: 8px 0;
+
+        &:first-of-type {
+          margin-top: 0;
+        }
+
+        &:last-of-type {
+          margin-bottom: 0;
+        }
+      }
     }
   }
 `;
@@ -39,6 +52,12 @@ const muiBreadcrumbs = () => css`
         margin: 0;
       }
     }
+  }
+`;
+
+const muiDivider = () => css`
+  .MuiDivider-root {
+    margin: 32px 0;
   }
 `;
 
@@ -76,6 +95,12 @@ export const Content = styled.div`
     }
   }
 
+  h1 + ol,
+  h1 + p,
+  h1 + ul {
+    margin-top: 16px;
+  }
+
   p {
     font: ${FONT.BODY_LARGE_400_2_LINES};
     margin: 0 0 16px;
@@ -85,6 +110,7 @@ export const Content = styled.div`
     }
   }
 
+  ol,
   ul {
     font: ${FONT.BODY_LARGE_400_2_LINES};
     margin: 16px 0;
@@ -95,6 +121,11 @@ export const Content = styled.div`
     }
   }
 
+  ol ol {
+    list-style-type: lower-roman;
+  }
+
   ${muiAlert};
   ${muiBreadcrumbs};
+  ${muiDivider};
 `;

--- a/app/content/common/constants.ts
+++ b/app/content/common/constants.ts
@@ -1,4 +1,5 @@
 import { ANCHOR_TARGET } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { Divider } from "@mui/material";
 import * as C from "../../components";
 import { Figure } from "../../components/common/Figure/figure";
 import { Link } from "../../components/Layout/components/Content/components/Link/link";
@@ -11,6 +12,7 @@ export const MDX_COMPONENTS = {
   Breadcrumbs: C.Breadcrumbs,
   Figure,
   a: Link,
+  hr: Divider,
 };
 
 export const MDX_SCOPE = { ANCHOR_TARGET };


### PR DESCRIPTION
Closes #304.

This pull request updates the styling and component mapping for content elements, focusing on improving the appearance and layout consistency of lists, headings, and dividers within the application. The most significant changes include enhanced list spacing, custom styling for nested lists, and the use of Material UI's `Divider` for horizontal rules in MDX content.

**Styling improvements for content layout:**

* Added custom spacing to `ol` and `ul` list items within alerts, ensuring better readability and consistent margins, with special handling for first and last items.
* Applied margin adjustments for elements (`ol`, `ul`, `p`) that follow `h1` headings to improve visual separation.
* Updated list styles to ensure `ol` and `ul` use consistent font and margin, and styled nested ordered lists (`ol ol`) to use lower-roman numerals. [[1]](diffhunk://#diff-5960974761f277e491261625ba66c5f9b0147ff3cb5102124b3a723938e8c6e2R113) [[2]](diffhunk://#diff-5960974761f277e491261625ba66c5f9b0147ff3cb5102124b3a723938e8c6e2R124-R130)

**Component and theme enhancements:**

* Introduced a `muiDivider` style to add vertical spacing to Material UI dividers and included it in the main content styles. [[1]](diffhunk://#diff-5960974761f277e491261625ba66c5f9b0147ff3cb5102124b3a723938e8c6e2R58-R63) [[2]](diffhunk://#diff-5960974761f277e491261625ba66c5f9b0147ff3cb5102124b3a723938e8c6e2R124-R130)
* Mapped the `hr` (horizontal rule) MDX element to the Material UI `Divider` component, ensuring consistent divider appearance in rendered content. [[1]](diffhunk://#diff-d29a090505bfa0b3b06be6a88c5ce75dc6dae0044676c3777c124755bc93b2d2R2) [[2]](diffhunk://#diff-d29a090505bfa0b3b06be6a88c5ce75dc6dae0044676c3777c124755bc93b2d2R15)

<img width="1742" height="1288" alt="image" src="https://github.com/user-attachments/assets/c62916e0-6c0f-4038-bf5b-cdb5ff2e14d9" />
