### PR TITLE
fix: responsive styles for example queries page (#317)

### DIFF
--- a/app/views/ExampleQueriesView/components/QueryChip/queryChip.styles.ts
+++ b/app/views/ExampleQueriesView/components/QueryChip/queryChip.styles.ts
@@ -4,6 +4,7 @@ import { Chip } from "@mui/material";
 
 export const StyledForm = styled("form")`
   display: inline;
+  min-width: 0;
 `;
 
 export const StyledChip = styled(Chip)`

--- a/app/views/ExampleQueriesView/exampleQueriesView.styles.ts
+++ b/app/views/ExampleQueriesView/exampleQueriesView.styles.ts
@@ -1,3 +1,4 @@
+import { bpDownSm } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
 import styled from "@emotion/styled";
 import { Stack } from "@mui/material";
 
@@ -10,4 +11,8 @@ export const StyledChipStack = styled(Stack)`
 
 export const StyledValueList = styled("ul")`
   column-count: 3;
+
+  ${bpDownSm} {
+    column-count: 1;
+  }
 `;


### PR DESCRIPTION
## Summary
- Add `min-width: 0` to query chip form to prevent overflow on narrow viewports
- Add responsive breakpoint to switch value list from 3 columns to 1 on small screens

## Test plan
- [ ] Verify example queries page renders correctly on desktop (3-column layout)
- [ ] Verify chips don't overflow on narrow viewports
- [ ] Verify single-column layout on mobile/small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)