### PR TITLE
chore: upgrade findable-ui to ^50.3.0 and next to ^15.5.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@mdx-js/react": "^3.0.1",
         "@mui/icons-material": "^7.3.6",
         "@mui/material": "^7.3.6",
-        "@next/mdx": "^15.5.9",
+        "@next/mdx": "^15.5.13",
         "@observablehq/plot": "^0.6.17",
         "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-table": "^8.21.3",
@@ -3986,9 +3986,9 @@
       }
     },
     "node_modules/@next/mdx": {
-      "version": "15.5.11",
-      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.5.11.tgz",
-      "integrity": "sha512-Abpg/k5K6Er3HgGZ68ChCHfonBXMqDr7Q28v80RA6zNCuBM0h9z6Dc7j2Xt5yM78muplMbeHzCaBev2CJAAIFg==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.5.14.tgz",
+      "integrity": "sha512-AZc3EHUfsQeKEEZoN+5GW0dvekIHLZ8nOBw2emT5GHs6KJlUYqg53a0bl62wH2lvmMbnsLh1lpZljOObwXekGQ==",
       "license": "MIT",
       "dependencies": {
         "source-map": "^0.7.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mdx-js/react": "^3.0.1",
     "@mui/icons-material": "^7.3.6",
     "@mui/material": "^7.3.6",
-    "@next/mdx": "^15.5.9",
+    "@next/mdx": "^15.5.13",
     "@observablehq/plot": "^0.6.17",
     "@tanstack/match-sorter-utils": "^8.19.4",
     "@tanstack/react-table": "^8.21.3",


### PR DESCRIPTION
## Summary

- Upgrade `@databiosphere/findable-ui` from `^49.6.0` to `^50.3.0`
- Bump `next`, `@next/eslint-plugin-next`, `eslint-config-next` from `^15.5.9` to `^15.5.13`

Closes #321

## Breaking change analysis

The v50 major bump was caused solely by a dependency floor bump (`next` ^15.5.9 → ^15.5.13). No APIs used by ncpi-dataset-catalog were removed or renamed — no code changes needed.

Other changes in v49.6.0 → v50.3.0 (all non-breaking for this repo):
- New `poweredByCC` footer prop (we use a custom footer)
- Dataset export analytics events (not used)
- Input converted to controlled component (no impact — we don't pass `onChange`/`value`)
- NIH account text updates (internal to findable-ui)

## Test plan

- [x] `npm install` resolves cleanly
- [x] `npm run build:dev` passes
- [x] `npm run lint` passes (only pre-existing warnings)
- [x] `npx jest --watchAll=false` — 146 tests pass
- [x] `npx playwright test` — 17/18 pass (1 pre-existing flaky test on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)