### PR TITLE
chore: upgrade findable-ui from ^50.3.0 to ^50.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ncpi-dataset-catalog",
       "version": "0.19.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^50.3.0",
+        "@databiosphere/findable-ui": "^50.6.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mdx-js/loader": "^3.0.1",
@@ -1049,10 +1049,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "50.3.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.3.0.tgz",
-      "integrity": "sha512-8UaACOxUXJgMicRsiAnNZ9k5b+zjtZxHdtXOmmGXXczstttwQwPaLNycKIPB2hVBD+LzJ6lXbU4ah+R59bVMxA==",
-      "license": "Apache-2.0",
+      "version": "50.6.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.6.0.tgz",
+      "integrity": "sha512-Cfjqf3b+w968APJ+uhgTjXagu8OFGPf/8afQPL3poBYN2UhOfvTjgCZ90auyWKifPK+6d1n9ptRrwOaMsNUOFg==",
       "engines": {
         "node": "22.12.0"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fetch-dbgap-selected-publications": "esrun catalog-build/fetch-dbgap-selected-publications.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^50.3.0",
+    "@databiosphere/findable-ui": "^50.6.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
## Summary

- Upgrades `@databiosphere/findable-ui` from `^50.3.0` to `^50.6.0`
- Changes between versions are all in the `ExportMethod` component (card-based layout, new `comingSoon`/`icon` props) — no breaking changes to APIs used by the catalog

Closes #334

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npm run build:dev` passes
- [ ] `npm run test:e2e` passes
- [ ] Export pages render correctly (`/export/get-curl-command`, `/export/export-to-terra`, `/export/download-manifest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)