### PR TITLE
chore: bump findable-ui to ^50.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ncpi-dataset-catalog",
       "version": "0.19.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^50.6.0",
+        "@databiosphere/findable-ui": "^50.6.1",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mdx-js/loader": "^3.0.1",
@@ -1049,9 +1049,10 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "50.6.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.6.0.tgz",
-      "integrity": "sha512-Cfjqf3b+w968APJ+uhgTjXagu8OFGPf/8afQPL3poBYN2UhOfvTjgCZ90auyWKifPK+6d1n9ptRrwOaMsNUOFg==",
+      "version": "50.6.1",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.6.1.tgz",
+      "integrity": "sha512-xXXWmZeBfRPSPSZRwnUoGllMi9wBy2xRqYp2Y8DpzCAGPXKuco+Gfyopg4HomMHOa6/EZVhDTap3mxo1ALU0zw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fetch-dbgap-selected-publications": "esrun catalog-build/fetch-dbgap-selected-publications.ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^50.6.0",
+    "@databiosphere/findable-ui": "^50.6.1",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
## Summary

- Bumps `@databiosphere/findable-ui` from `^50.6.0` to `^50.6.1`
- Picks up the `files` field fix from DataBiosphere/findable-ui#864, reducing npm install size from 150MB to ~1MB

Closes #334

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 18 Playwright E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)