### PR TITLE
chore: add link-findable and unlink-findable npm scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ncpi-dataset-catalog",
       "version": "0.19.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^50.6.1",
+        "@databiosphere/findable-ui": "^50.7.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mdx-js/loader": "^3.0.1",
@@ -1049,9 +1049,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "50.6.1",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.6.1.tgz",
-      "integrity": "sha512-xXXWmZeBfRPSPSZRwnUoGllMi9wBy2xRqYp2Y8DpzCAGPXKuco+Gfyopg4HomMHOa6/EZVhDTap3mxo1ALU0zw==",
+      "version": "50.7.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.7.0.tgz",
+      "integrity": "sha512-4ISwTcj2Tdbj5vgHt8mb1bkBcP6LDqP1zaEbl/R5nh0u8BNnine9/fbXS7wT4MaiYbCNclMKucZ1qowcH+KlSQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "update-kfdrc-source": "esrun catalog-build/update-kfdrc-source.ts",
     "update-dbgap-source": "esrun catalog-build/update-dbgap-source.ts",
     "update-all-ncpi-sources": "npm run update-crdc-source && npm run update-bdc-source && npm run update-anvil-source && npm run update-kfdrc-source && npm run update-dbgap-source",
-    "fetch-dbgap-selected-publications": "esrun catalog-build/fetch-dbgap-selected-publications.ts"
+    "fetch-dbgap-selected-publications": "esrun catalog-build/fetch-dbgap-selected-publications.ts",
+    "link-findable": "../findable-ui/scripts/link.sh",
+    "unlink-findable": "../findable-ui/scripts/unlink.sh"
   },
   "dependencies": {
     "@databiosphere/findable-ui": "^50.6.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "unlink-findable": "../findable-ui/scripts/unlink.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^50.6.1",
+    "@databiosphere/findable-ui": "^50.7.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mdx-js/loader": "^3.0.1",


### PR DESCRIPTION
## Summary

- Adds `link-findable` and `unlink-findable` npm scripts as thin wrappers around `../findable-ui/scripts/link.sh` and `unlink.sh`
- Enables `npm run link-findable` for local co-development with findable-ui

See DataBiosphere/findable-ui#867 for the scripts themselves.

Closes #322

## Test plan

- [x] `npm run link-findable` builds, installs local findable-ui, clears cache, starts dev server
- [x] `npm run unlink-findable` restores registry version
- [x] Verified with console.log marker that local changes are reflected

🤖 Generated with [Claude Code](https://claude.com/claude-code)