### PR TITLE
ci: add GitHub Actions workflow for analytics site deployment #341

### DIFF
--- a/.github/workflows/deploy-analytics.yml
+++ b/.github/workflows/deploy-analytics.yml
@@ -1,0 +1,40 @@
+name: Deploy Analytics Site
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "analytics/site/**"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "analytics/site"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Ticket
Closes #341

## Summary
- Add GitHub Actions workflow to deploy `analytics/site/` to GitHub Pages
- Triggers on manual dispatch or push to main when `analytics/site/**` changes
- Uses `actions/deploy-pages@v4` for deployment

## Setup required after merge
1. Go to repo **Settings → Pages**
2. Set **Source** to **GitHub Actions**
3. Trigger manually from **Actions → Deploy Analytics Site → Run workflow**, or push a change to `analytics/site/`

## Test plan
- [ ] Merge PR
- [ ] Enable GitHub Pages with Actions source in repo settings
- [ ] Run workflow manually from Actions tab
- [ ] Verify site is live at https://nih-ncpi.github.io/ncpi-dataset-catalog/

🤖 Generated with [Claude Code](https://claude.ai/claude-code)