### PR TITLE
fix: move state providers inside errorboundary to prevent crash loop (#348)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -114,33 +114,33 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                     <StyledHeader {...header} transparent={homePage} />
                   </ThemeProvider>
                   <ChatProvider initialArgs={ai?.prompt} url={aiUrl}>
-                    <ExploreStateProvider entityListType={entityListType}>
-                      <DataDictionaryStateProvider>
-                        <FileManifestStateProvider>
-                          <Main>
-                            <ErrorBoundary
-                              fallbackRender={({
-                                error,
-                                reset,
-                              }: {
-                                error: DataExplorerError;
-                                reset: () => void;
-                              }): JSX.Element => (
-                                <DXError
-                                  errorMessage={error.message}
-                                  requestUrlMessage={error.requestUrlMessage}
-                                  rootPath={redirectRootToPath}
-                                  onReset={reset}
-                                />
-                              )}
-                            >
+                    <Main>
+                      <ErrorBoundary
+                        fallbackRender={({
+                          error,
+                          reset,
+                        }: {
+                          error: DataExplorerError;
+                          reset: () => void;
+                        }): JSX.Element => (
+                          <DXError
+                            errorMessage={error.message}
+                            requestUrlMessage={error.requestUrlMessage}
+                            rootPath={redirectRootToPath}
+                            onReset={reset}
+                          />
+                        )}
+                      >
+                        <ExploreStateProvider entityListType={entityListType}>
+                          <DataDictionaryStateProvider>
+                            <FileManifestStateProvider>
                               <Component {...pageProps} />
                               <Floating {...floating} />
-                            </ErrorBoundary>
-                          </Main>
-                        </FileManifestStateProvider>
-                      </DataDictionaryStateProvider>
-                    </ExploreStateProvider>
+                            </FileManifestStateProvider>
+                          </DataDictionaryStateProvider>
+                        </ExploreStateProvider>
+                      </ErrorBoundary>
+                    </Main>
                   </ChatProvider>
                   <Footer />
                 </AppLayout>


### PR DESCRIPTION
## Summary
- Move `ExploreStateProvider`, `DataDictionaryStateProvider`, and `FileManifestStateProvider` inside the `ErrorBoundary` in `pages/_app.tsx`
- Prevents infinite crash loop when a reducer/hook error occurs in these providers (errors now caught by the boundary and display the error fallback UI)
- Header and Footer remain outside so users can still navigate away from the error page

Relates to [DataBiosphere/findable-ui#888](https://github.com/DataBiosphere/findable-ui/issues/888).

Closes #348.

## Test plan
- [x] TypeScript compiles cleanly
- [x] Build succeeds (`next build`)
- [x] All 147 Jest tests pass
- [ ] E2E tests (require backend server — will run in CI)
- [x] Manual: trigger a filter query param error and verify the error page renders instead of crash loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)