### PR TITLE
fix: revert providers outside ErrorBoundary and upgrade findable-ui to v51.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ncpi-dataset-catalog",
       "version": "0.19.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^51.0.1",
+        "@databiosphere/findable-ui": "^51.1.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mdx-js/loader": "^3.0.1",
@@ -1048,9 +1048,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "51.0.1",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.1.tgz",
-      "integrity": "sha512-kHHf38QoQUJP+LQAPFKmGuOdZWWeb8Fjer+1CgIa8CryAnGI4HGNQT1KetrnMP0KuPRVOw3VmQOtzsynSdauKg==",
+      "version": "51.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.1.0.tgz",
+      "integrity": "sha512-aWy0zOOGim5xoJvWes1v/mqKSobBUlGmfZt4uIMp5f+oNKEFlAA27CSJ01SsbhWQKgpPdZT3f+kXxfYG0FDk+A==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "unlink-findable": "../findable-ui/scripts/unlink.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^51.0.1",
+    "@databiosphere/findable-ui": "^51.1.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mdx-js/loader": "^3.0.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -114,33 +114,33 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                     <StyledHeader {...header} transparent={homePage} />
                   </ThemeProvider>
                   <ChatProvider initialArgs={ai?.prompt} url={aiUrl}>
-                    <Main>
-                      <ErrorBoundary
-                        fallbackRender={({
-                          error,
-                          reset,
-                        }: {
-                          error: DataExplorerError;
-                          reset: () => void;
-                        }): JSX.Element => (
-                          <DXError
-                            errorMessage={error.message}
-                            requestUrlMessage={error.requestUrlMessage}
-                            rootPath={redirectRootToPath}
-                            onReset={reset}
-                          />
-                        )}
-                      >
-                        <ExploreStateProvider entityListType={entityListType}>
-                          <DataDictionaryStateProvider>
-                            <FileManifestStateProvider>
+                    <ExploreStateProvider entityListType={entityListType}>
+                      <DataDictionaryStateProvider>
+                        <FileManifestStateProvider>
+                          <Main>
+                            <ErrorBoundary
+                              fallbackRender={({
+                                error,
+                                reset,
+                              }: {
+                                error: DataExplorerError;
+                                reset: () => void;
+                              }): JSX.Element => (
+                                <DXError
+                                  errorMessage={error.message}
+                                  requestUrlMessage={error.requestUrlMessage}
+                                  rootPath={redirectRootToPath}
+                                  onReset={reset}
+                                />
+                              )}
+                            >
                               <Component {...pageProps} />
                               <Floating {...floating} />
-                            </FileManifestStateProvider>
-                          </DataDictionaryStateProvider>
-                        </ExploreStateProvider>
-                      </ErrorBoundary>
-                    </Main>
+                            </ErrorBoundary>
+                          </Main>
+                        </FileManifestStateProvider>
+                      </DataDictionaryStateProvider>
+                    </ExploreStateProvider>
                   </ChatProvider>
                   <Footer />
                 </AppLayout>


### PR DESCRIPTION
## Summary

Reverts `ExploreStateProvider`, `DataDictionaryStateProvider`, and `FileManifestStateProvider` to their original position outside the `ErrorBoundary` and upgrades findable-ui to v51.1.0, which fixes the infinite crash loop at the library level.

### Why revert

PR #349 moved the providers inside the `ErrorBoundary` to catch reducer crashes. This fixed the crash loop but caused **state loss** when navigating between pages.

### Why this works without the provider move

findable-ui v51.1.0 ([PR #899](https://github.com/DataBiosphere/findable-ui/pull/899)) fixes the root cause:

- **`parseFilterParam`** — safely validates filter URL params without throwing (prevents reducer crash above ErrorBoundary)
- **`useValidateFilterParam`** hook — runs inside ExploreView (inside ErrorBoundary), validates the URL filter param directly, throws `DataExplorerError` for invalid filters so the error page renders
- **`ErrorBoundary`** — fixes `this.render` → `this.reset` typo
- **`useAsync.run()`** — clears stale error on new request

### Note on CS filtering behaviour

This app uses client-side fetch with client-side filtering, so the valid-shape-invalid-values test case behaves differently:

- **Valid `categoryKey`, bogus value** — renders the value as a filter chip that can be removed, but since the data doesn't contain the term, shows "No Results found". This is a good outcome.
- **Invalid `categoryKey`** (e.g. `?filter=[{"categoryKey":"bogus","value":["invalid"]}]`) — fails silently with no filters applied and no notice to the user.

Closes #350

## Reference

- Umbrella: DataBiosphere/findable-ui#900
- Findable-ui fix: https://github.com/DataBiosphere/findable-ui/pull/899
- Provider move being reverted: #349

## Test plan
- [x] Lint passes
- [x] Prettier passes
- [x] TypeScript compiles
- [x] Manual: malformed JSON filter → error page, no loop
- [x] Manual: wrong shape filter → error page, no loop
- [x] Manual: valid filters work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)