### PR TITLE
feat(analytics): update analytics page for April 2026

### DIFF
--- a/analytics/constants.py
+++ b/analytics/constants.py
@@ -1,8 +1,8 @@
 # CHANGE THESE VALUES TO GENERATE NEW REPORTS
 # The date of the current month to report on (yyyy-mm)
-CURRENT_MONTH = "2026-03"
+CURRENT_MONTH = "2026-04"
 # The name of the folder in which to save the report
-PARENT_FOLDER_NAME = "March 2026"
+PARENT_FOLDER_NAME = "April 2026"
 
 # The name of the spreadsheet with the report
 SHEET_NAME = "NCPI Catalog"

--- a/analytics/generate_static_site.py
+++ b/analytics/generate_static_site.py
@@ -88,9 +88,17 @@ def get_chat_submitted_change(params_current, params_prior):
     return {"current": current_count, "prior": prior_count, "change": change}
 
 
+METRIC_ENGAGEMENT_RATE = {
+    "id": "engagementRate",
+    "alias": "Engagement Rate",
+}
+
+
 def fetch_data(ga_authentication):
     """Fetch analytics data using the analytics package."""
     import analytics.sheets_elements as elements
+    from analytics.sheets_elements import get_data_df_from_fields
+    from analytics.entities import METRIC_SESSIONS
 
     # Calculate date ranges
     report_dates = elements.get_bounds_for_month_and_prev(CURRENT_MONTH)
@@ -163,9 +171,29 @@ def fetch_data(ga_authentication):
         ncpi_catalog_params, ncpi_catalog_params_prior
     )
 
+    print("Fetching sessions and engagement data...")
+    df_sessions_current = get_data_df_from_fields(
+        [METRIC_SESSIONS, METRIC_ENGAGEMENT_RATE], [], **ncpi_catalog_params,
+    )
+    df_sessions_prior = get_data_df_from_fields(
+        [METRIC_SESSIONS, METRIC_ENGAGEMENT_RATE], [], **ncpi_catalog_params_prior,
+    )
+    sessions_current = int(df_sessions_current[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_current) > 0 else 0
+    sessions_prior = int(df_sessions_prior[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_prior) > 0 else 0
+    engagement_current = float(df_sessions_current[METRIC_ENGAGEMENT_RATE["alias"]].mean()) if len(df_sessions_current) > 0 else 0
+    engagement_prior = float(df_sessions_prior[METRIC_ENGAGEMENT_RATE["alias"]].mean()) if len(df_sessions_prior) > 0 else 0
+
     print("Data fetching complete!")
 
     return {
+        "sessions": {
+            "current": sessions_current,
+            "prior": sessions_prior,
+        },
+        "engagement_rate": {
+            "current": engagement_current,
+            "prior": engagement_prior,
+        },
         "monthly_traffic": df_monthly_traffic,
         "pageviews": df_pageviews,
         "outbound": df_outbound,
@@ -257,8 +285,8 @@ def export_data(data, output_dir="site/data"):
     print("Exporting filter selections data...")
     _export_df_as_json(
         data.get("filter_selected"),
-        {"Filter Name": "filterName", "Filter Value": "filterValue", "Total Events": "count"},
-        "Total Events Change",
+        {"Filter Name": "filterName", "Filter Value": "filterValue", "Event Count": "count"},
+        "Event Count Change",
         "filter_selected.json",
         output_dir,
     )
@@ -281,6 +309,8 @@ def export_data(data, output_dir="site/data"):
         "prior_month_start": dates.get("start_prior", ""),
         "prior_month_end": dates.get("end_prior", ""),
         "analytics_start": ANALYTICS_START,
+        "sessions": data.get("sessions", {}),
+        "engagement_rate": data.get("engagement_rate", {}),
     }
 
     with open(os.path.join(output_dir, "meta.json"), "w") as f:

--- a/analytics/generate_static_site.py
+++ b/analytics/generate_static_site.py
@@ -180,8 +180,8 @@ def fetch_data(ga_authentication):
     )
     sessions_current = int(df_sessions_current[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_current) > 0 else 0
     sessions_prior = int(df_sessions_prior[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_prior) > 0 else 0
-    engagement_current = float(df_sessions_current[METRIC_ENGAGEMENT_RATE["alias"]].mean()) if len(df_sessions_current) > 0 else 0
-    engagement_prior = float(df_sessions_prior[METRIC_ENGAGEMENT_RATE["alias"]].mean()) if len(df_sessions_prior) > 0 else 0
+    engagement_current = float(df_sessions_current[METRIC_ENGAGEMENT_RATE["alias"]].mean()) if len(df_sessions_current) > 0 else None
+    engagement_prior = float(df_sessions_prior[METRIC_ENGAGEMENT_RATE["alias"]].mean()) if len(df_sessions_prior) > 0 else None
 
     print("Data fetching complete!")
 

--- a/analytics/generate_static_site.py
+++ b/analytics/generate_static_site.py
@@ -180,8 +180,10 @@ def fetch_data(ga_authentication):
     )
     sessions_current = int(df_sessions_current[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_current) > 0 else 0
     sessions_prior = int(df_sessions_prior[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_prior) > 0 else 0
-    engagement_current = float(df_sessions_current[METRIC_ENGAGEMENT_RATE["alias"]].mean()) if len(df_sessions_current) > 0 else None
-    engagement_prior = float(df_sessions_prior[METRIC_ENGAGEMENT_RATE["alias"]].mean()) if len(df_sessions_prior) > 0 else None
+    _eng_current = df_sessions_current[METRIC_ENGAGEMENT_RATE["alias"]].mean() if len(df_sessions_current) > 0 else None
+    _eng_prior = df_sessions_prior[METRIC_ENGAGEMENT_RATE["alias"]].mean() if len(df_sessions_prior) > 0 else None
+    engagement_current = float(_eng_current) if _eng_current is not None and not pd.isna(_eng_current) else None
+    engagement_prior = float(_eng_prior) if _eng_prior is not None and not pd.isna(_eng_prior) else None
 
     print("Data fetching complete!")
 

--- a/analytics/site/data/chat_submitted.json
+++ b/analytics/site/data/chat_submitted.json
@@ -1,5 +1,5 @@
 {
-  "current": 63,
-  "prior": 0,
-  "change": null
+  "current": 41,
+  "prior": 63,
+  "change": -0.3492063492063492
 }

--- a/analytics/site/data/filter_selected.json
+++ b/analytics/site/data/filter_selected.json
@@ -2,90 +2,48 @@
   {
     "filterName": "platform",
     "filterValue": "KFDRC",
-    "count": 2,
-    "change": 0.8064516129032258
+    "count": 0,
+    "change": -1.0
   },
   {
     "filterName": "dataType",
     "filterValue": "RNA-Seq",
-    "count": 1,
-    "change": -0.09677419354838712
+    "count": 0,
+    "change": -1.0
   },
   {
     "filterName": "focus",
     "filterValue": "Asthma",
-    "count": 1,
-    "change": null
+    "count": 0,
+    "change": -1.0
   },
   {
     "filterName": "platform",
     "filterValue": "AnVIL",
-    "count": 1,
-    "change": -0.5483870967741935
+    "count": 0,
+    "change": -1.0
   },
   {
     "filterName": "platform",
     "filterValue": "BDC",
-    "count": 1,
-    "change": -0.09677419354838712
+    "count": 0,
+    "change": -1.0
   },
   {
     "filterName": "platform",
     "filterValue": "CRDC",
-    "count": 1,
-    "change": null
+    "count": 0,
+    "change": -1.0
   },
   {
     "filterName": "platform",
     "filterValue": "dbGaP",
-    "count": 1,
-    "change": null
+    "count": 0,
+    "change": -1.0
   },
   {
     "filterName": "title",
     "filterValue": "The Cancer Genome Atlas (TCGA)",
-    "count": 1,
-    "change": null
-  },
-  {
-    "filterName": "dbGapId",
-    "filterValue": "phs000001",
-    "count": 0,
-    "change": -1.0
-  },
-  {
-    "filterName": "dbGapId",
-    "filterValue": "phs000220",
-    "count": 0,
-    "change": -1.0
-  },
-  {
-    "filterName": "dbGapId",
-    "filterValue": "phs003046",
-    "count": 0,
-    "change": -1.0
-  },
-  {
-    "filterName": "focus",
-    "filterValue": "COVID-19",
-    "count": 0,
-    "change": -1.0
-  },
-  {
-    "filterName": "focus",
-    "filterValue": "Neoplasms",
-    "count": 0,
-    "change": -1.0
-  },
-  {
-    "filterName": "title",
-    "filterValue": "Center for Common Disease Genomics [CCDG] - Cardiovascular ATVB:    Atherosclerosis Thrombosis and V",
-    "count": 0,
-    "change": -1.0
-  },
-  {
-    "filterName": "title",
-    "filterValue": "The Multiethnic Cohort (MEC) Study",
     "count": 0,
     "change": -1.0
   }

--- a/analytics/site/data/meta.json
+++ b/analytics/site/data/meta.json
@@ -1,9 +1,17 @@
 {
-  "generated_at": "2026-04-17 11:56:44",
-  "current_month": "2026-03",
-  "current_month_start": "2026-03-01",
-  "current_month_end": "2026-03-31",
-  "prior_month_start": "2026-02-01",
-  "prior_month_end": "2026-02-28",
-  "analytics_start": "2023-07-01"
+  "generated_at": "2026-05-06 10:49:24",
+  "current_month": "2026-04",
+  "current_month_start": "2026-04-01",
+  "current_month_end": "2026-04-30",
+  "prior_month_start": "2026-03-01",
+  "prior_month_end": "2026-03-31",
+  "analytics_start": "2023-07-01",
+  "sessions": {
+    "current": 514,
+    "prior": 470
+  },
+  "engagement_rate": {
+    "current": 0.19066147859922178,
+    "prior": 0.23404255319148937
+  }
 }

--- a/analytics/site/data/monthly_traffic.json
+++ b/analytics/site/data/monthly_traffic.json
@@ -1,5 +1,10 @@
 [
   {
+    "month": "2026-04",
+    "users": 434,
+    "pageviews": 687
+  },
+  {
     "month": "2026-03",
     "users": 388,
     "pageviews": 792

--- a/analytics/site/data/outbound_links.json
+++ b/analytics/site/data/outbound_links.json
@@ -1,271 +1,221 @@
 [
   {
-    "link": "https://ncpi-acc.org/",
-    "clicks": 5,
-    "change": 1.7096774193548385
+    "link": "https://doi.org/10.1038/ng.687",
+    "clicks": 2,
+    "change": null
   },
   {
-    "link": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_id",
-    "clicks": 2,
-    "change": -0.09677419354838712
+    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000091.v2.p1",
+    "clicks": 1,
+    "change": null
   },
   {
-    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/variable.cgi?study_id=phs000220.v2.p2&phv=00163107",
-    "clicks": 2,
+    "link": "https://doi.org/10.1093/brain/awz063",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://doi.org/10.1586/erv.12.134",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://doi.org/10.1016/J.JACC.2006.04.089",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://doi.org/10.1161/JAHA.113.000092",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://doi.org/10.1093/hmg/ddt519",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://portal.gdc.cancer.gov/projects/TARGET-OS",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs000468",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://doi.org/10.1038/ng.3879",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/variable.cgi?study_id=phs001349.v2.p1&phv=00431284",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001497.v2.p1",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001579.v1.p1",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001612.v3.p3",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://doi.org/10.1056/NEJMoa1001278",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://doi.org/10.1038/s41590-019-0544-5",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://doi.org/10.1172/JCI150634",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://doi.org/10.1161/01.STR.0000142374.33919.92",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs002465",
+    "clicks": 1,
+    "change": null
+  },
+  {
+    "link": "https://gen3.biodatacatalyst.nhlbi.nih.gov/discovery",
+    "clicks": 1,
     "change": null
   },
   {
     "link": "https://github.com/NIH-NCPI/ncpi-dataset-catalog/releases/tag/v0.13.1",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
+  },
+  {
+    "link": "https://ncpi-acc.org/",
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://clevercanary.com/",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://dbgap.ncbi.nlm.nih.gov/study/phs000007",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://dbgap.ncbi.nlm.nih.gov/study/phs000701",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://github.com/NIH-NCPI/ncpi-dataset-catalog/commit/55c73f9ee86afdef56b6d980ce6be80ce500b8c8",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://github.com/NIH-NCPI/ncpi-dataset-catalog/issues/new?template=feedback.md",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/variable.cgi?study_id=phs000667.v4.p1&phv=00225921",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://github.com/NIH-NCPI/ncpi-dataset-catalog/commit/c2f9b4b82887fe959d1d1d0a9dffc94718af8d03",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
+  },
+  {
+    "link": "https://explore.anvilproject.org/datasets?filter=%5B%7B%22categoryKey%22%3A%22datasets.registered_id",
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs000220",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
+  },
+  {
+    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/variable.cgi?study_id=phs000220.v2.p2&phv=00163107",
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/variable.cgi?study_id=phs000220.v2.p2&phv=00163122",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/variable.cgi?study_id=phs000220.v2.p2&phv=00163126",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://dbgap-api.ncbi.nlm.nih.gov/fhir/x1/ResearchStudy?_id=phs000274&_format=json",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/variable.cgi?study_id=phs000298.v4.p3&phv=00369219",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://portal.gdc.cancer.gov/projects/TARGET-ALL-P2",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001605.v3.p1",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs001931",
-    "clicks": 1,
-    "change": -0.09677419354838712
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/variable.cgi?study_id=phs001931.v1.p1&phv=00421127",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://sleepdata.org/",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://sleepdata.org/datasets/cfs",
-    "clicks": 1,
-    "change": -0.09677419354838712
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://www.ncbi.nlm.nih.gov/books/NBK5295/",
-    "clicks": 1,
-    "change": null
+    "clicks": 0,
+    "change": -1.0
   },
   {
     "link": "https://curesickle.org/cde-catalog",
-    "clicks": 1,
-    "change": null
-  },
-  {
-    "link": "https://github.com/NIH-NCPI/ncpi-dataset-catalog",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://github.com/NIH-NCPI/ncpi-dataset-catalog/releases/tag/v0.5.0",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://dbgap-api.ncbi.nlm.nih.gov/fhir/x1/ResearchStudy?_id=phs000209&_format=json",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs000209",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "http://ocg.cancer.gov/programs/target",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://dbgap-api.ncbi.nlm.nih.gov/fhir/x1/ResearchStudy?_id=phs000465&_format=json",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs000465",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://portal.gdc.cancer.gov/projects/TARGET-AML",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://portal.kidsfirstdrc.org/public-studies",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.cancer.gov/ccg/research/genome-sequencing/target/using-target-data/citing",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000465.v23.p8",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.cancer.gov/ccg/research/genome-sequencing/target",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.cancer.gov/ccg/research/genome-sequencing/target",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "http://beacon.tlvnet.net/",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000921.v5.p2",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs000951",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.ncbi.nlm.nih.gov/books/NBK5295/",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000179",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://doi.org/10.1161/CIRCEP.113.000253",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001184",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001598.v3.p1",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs001608",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.ncbi.nlm.nih.gov/pubmed/24478166",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.youtube.com/watch?v=m0xp_cCO7kA",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs001963",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://doi.org/10.1093/OXFORDJOURNALS.AJE.A010213",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs002808",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?adddataset=phs003543",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs003543.v1.p1",
-    "clicks": 0,
-    "change": -1.0
-  },
-  {
-    "link": "https://pubmed.ncbi.nlm.nih.gov/25602358/",
     "clicks": 0,
     "change": -1.0
   }

--- a/analytics/site/data/pageviews.json
+++ b/analytics/site/data/pageviews.json
@@ -1,991 +1,1941 @@
 [
   {
     "page": "/",
-    "views": 209,
-    "change": 1.6790595954073266
-  },
-  {
-    "page": "/platforms",
-    "views": 132,
-    "change": -0.4509803921568628
+    "views": 221,
+    "change": 0.09266347687400334
   },
   {
     "page": "/research/studies",
-    "views": 83,
-    "change": null
+    "views": 75,
+    "change": -0.0662650602409639
   },
   {
     "page": "/studies",
-    "views": 58,
-    "change": -0.2869269949066213
+    "views": 29,
+    "change": -0.4833333333333334
   },
   {
-    "page": "/about",
-    "views": 16,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000220",
-    "views": 12,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs002715",
-    "views": 10,
-    "change": 0.20430107526881724
-  },
-  {
-    "page": "/research/studies/phs001840",
-    "views": 9,
-    "change": null
-  },
-  {
-    "page": "/data-dictionaries/ncpi-dataset-catalog",
-    "views": 7,
-    "change": 0.08387096774193559
+    "page": "/platforms",
+    "views": 15,
+    "change": -0.8825757575757576
   },
   {
     "page": "/example-queries",
-    "views": 7,
-    "change": null
+    "views": 12,
+    "change": 0.7714285714285714
   },
   {
-    "page": "/studies/phs000220/variables",
+    "page": "/data-dictionaries/ncpi-dataset-catalog",
+    "views": 9,
+    "change": 0.3285714285714285
+  },
+  {
+    "page": "/studies/phs000468",
     "views": 6,
     "change": null
   },
   {
-    "page": "/studies/phs000964",
-    "views": 5,
-    "change": 3.516129032258064
-  },
-  {
-    "page": "/studies/phs000465",
-    "views": 5,
-    "change": -0.3978494623655914
-  },
-  {
-    "page": "/research/studies/phs001840/variables",
-    "views": 5,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000220/selected-publications",
-    "views": 5,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/status",
+    "page": "/studies/phs001168",
     "views": 4,
     "change": null
   },
   {
-    "page": "/studies/phs000464/",
+    "page": "/studies/phs001194",
     "views": 4,
-    "change": null
+    "change": 1.0666666666666664
   },
   {
-    "page": "/studies/phs000465/",
-    "views": 4,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000467",
-    "views": 4,
-    "change": -0.4580645161290322
-  },
-  {
-    "page": "/research/studies/phs001228",
-    "views": 4,
-    "change": null
-  },
-  {
-    "page": "/studies/phs002975",
-    "views": 4,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs000220/",
+    "page": "/about",
     "views": 3,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001179/",
-    "views": 3,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001735/",
-    "views": 3,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001931/",
-    "views": 3,
-    "change": null
-  },
-  {
-    "page": "/studies/phs002383/",
-    "views": 3,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000424",
-    "views": 3,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs001931",
-    "views": 3,
-    "change": -0.6989247311827957
-  },
-  {
-    "page": "/chat",
-    "views": 2,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs000122",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000178",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000178/",
-    "views": 2,
-    "change": 0.8064516129032258
-  },
-  {
-    "page": "/studies/phs000285/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000289/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000439/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000466/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000467/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000470",
-    "views": 2,
-    "change": 0.8064516129032258
+    "change": -0.80625
   },
   {
     "page": "/studies/phs000470/",
+    "views": 3,
+    "change": 0.55
+  },
+  {
+    "page": "/studies/phs001179",
+    "views": 3,
+    "change": 0.55
+  },
+  {
+    "page": "/studies/phs000007",
+    "views": 3,
+    "change": 2.1
+  },
+  {
+    "page": "/studies/phs000200",
+    "views": 3,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000346/selected-publications",
+    "views": 3,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000703",
+    "views": 3,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002928/variables",
     "views": 2,
     "change": null
   },
   {
-    "page": "/studies/phs000741/",
+    "page": "/status",
     "views": 2,
-    "change": 0.8064516129032258
+    "change": -0.4833333333333334
   },
   {
-    "page": "/studies/phs000810",
+    "page": "/studies/phs000200/",
+    "views": 2,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000209",
+    "views": 2,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000220",
+    "views": 2,
+    "change": -0.8277777777777777
+  },
+  {
+    "page": "/studies/phs000467",
+    "views": 2,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs000468/variables",
     "views": 2,
     "change": null
   },
   {
     "page": "/studies/phs000892/",
     "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000914/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000925",
-    "views": 2,
-    "change": 0.8064516129032258
+    "change": 0.033333333333333215
   },
   {
     "page": "/studies/phs001138/",
     "views": 2,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
-    "page": "/studies/phs001194",
+    "page": "/studies/phs001211",
     "views": 2,
     "change": null
   },
   {
-    "page": "/studies/phs001217/",
-    "views": 2,
-    "change": 0.8064516129032258
-  },
-  {
-    "page": "/studies/phs001222/",
+    "page": "/studies/phs001579",
     "views": 2,
     "change": null
   },
   {
-    "page": "/studies/phs001287",
+    "page": "/studies/phs001732/",
     "views": 2,
     "change": null
   },
   {
-    "page": "/studies/phs001287/",
+    "page": "/studies/phs002383/",
     "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001345",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001466/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001486/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001489/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001628/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001657/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001927/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs002348/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs002363/",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs002385",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs002385/",
-    "views": 2,
-    "change": null
+    "change": -0.3111111111111111
   },
   {
     "page": "/studies/phs002694/",
     "views": 2,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
-    "page": "/studies/phs003593",
+    "page": "/studies/phs002715",
+    "views": 2,
+    "change": -0.7933333333333333
+  },
+  {
+    "page": "/studies/phs003743/selected-publications",
     "views": 2,
     "change": null
   },
   {
-    "page": "/research/studies/phs000007",
+    "page": "/research/studies/phs001610",
     "views": 2,
     "change": null
   },
   {
-    "page": "/research/studies/phs000090",
+    "page": "/research/studies/phs001630",
     "views": 2,
     "change": null
   },
   {
-    "page": "/research/studies/phs000925",
+    "page": "/research/studies/phs001630/variables",
     "views": 2,
     "change": null
   },
   {
-    "page": "/research/studies/phs000956",
+    "page": "/studies/phs000703/variables",
     "views": 2,
     "change": null
   },
   {
-    "page": "/research/studies/phs001048/variables",
+    "page": "/studies/phs001704",
     "views": 2,
     "change": null
   },
   {
-    "page": "/research/studies/phs001228/selected-publications",
+    "page": "/studies/phs002406/selected-publications",
     "views": 2,
     "change": null
   },
   {
-    "page": "/research/studies/phs001840/selected-publications",
+    "page": "/studies/phs002465/selected-publications",
     "views": 2,
     "change": null
   },
   {
-    "page": "/studies/phs000298",
-    "views": 2,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs000298/selected-publications",
-    "views": 2,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs000298/variables",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/studies/phs001179",
-    "views": 2,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs001931/variables",
-    "views": 2,
-    "change": null
-  },
-  {
-    "page": "/research/chat",
+    "page": "/research/studies/phs000006/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000007/selected-publications",
+    "page": "/research/studies/phs000091",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000007/variables",
+    "page": "/research/studies/phs000142",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000280",
+    "page": "/research/studies/phs000384/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000286",
+    "page": "/research/studies/phs000404/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs000416/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs000439/selected-publications",
     "views": 1,
     "change": null
   },
   {
     "page": "/research/studies/phs000462",
     "views": 1,
+    "change": 0.033333333333333215
+  },
+  {
+    "page": "/research/studies/phs000462/selected-publications",
+    "views": 1,
     "change": null
   },
   {
     "page": "/research/studies/phs000462/variables",
     "views": 1,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
-    "page": "/research/studies/phs000516",
+    "page": "/research/studies/phs000486/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000571",
+    "page": "/research/studies/phs000487/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000571/selected-publications",
+    "page": "/research/studies/phs000495/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000667",
+    "page": "/research/studies/phs000511/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000667/variables",
+    "page": "/research/studies/phs000550/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000925/variables",
+    "page": "/research/studies/phs000555",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs000956/variables",
+    "page": "/research/studies/phs000582/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs001048",
+    "page": "/research/studies/phs000588/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs001999",
+    "page": "/research/studies/phs000675/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs003002",
+    "page": "/research/studies/phs000687",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs003600",
+    "page": "/research/studies/phs000797",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs003887",
+    "page": "/research/studies/phs000820/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs003887/selected-publications",
+    "page": "/research/studies/phs000871/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/research/studies/phs003887/variables",
+    "page": "/research/studies/phs000895",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000001",
+    "page": "/research/studies/phs000939/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000006",
+    "page": "/research/studies/phs000959/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000007",
+    "page": "/research/studies/phs001004",
     "views": 1,
-    "change": -0.09677419354838712
+    "change": null
   },
   {
-    "page": "/studies/phs000007/",
+    "page": "/research/studies/phs001012/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001046/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001158",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001158/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001181/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001181/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001188",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001188/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001188/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001228",
+    "views": 1,
+    "change": -0.7416666666666667
+  },
+  {
+    "page": "/research/studies/phs001228/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001274/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001306/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001360",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001379/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001416/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001436",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001458",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001502/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001525/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001542/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001553",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001598/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001630/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001644",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001686/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001735/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001740",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001841",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs001967",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002070/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002171/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002208",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002221",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002273/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002369/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002388",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002391/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002406/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002576/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs002595/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003042/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003042/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003055/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003085/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003156",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003164",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003251/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003321/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003410",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003490/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003500/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003519/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003599/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003644/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003654",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003658",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003702/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003726",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003766/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003835/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003841/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs003954/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs004024/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs004049/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs004112",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs004182/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/research/studies/phs004188/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000007/variables",
     "views": 1,
     "change": null
   },
   {
     "page": "/studies/phs000016",
     "views": 1,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
     "page": "/studies/phs000017",
     "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000018",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000019",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000020",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000021",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000086",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000088",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000089",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000090",
-    "views": 1,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
     "page": "/studies/phs000091",
     "views": 1,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
-    "page": "/studies/phs000092",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000093",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000094",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000095",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000096",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000100",
-    "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000101",
+    "page": "/studies/phs000091/selected-publications",
     "views": 1,
     "change": null
   },
   {
     "page": "/studies/phs000102",
     "views": 1,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
-    "page": "/studies/phs000103",
+    "page": "/studies/phs000122",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs000179/",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000125",
+    "page": "/studies/phs000209/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000126",
+    "page": "/studies/phs000220/selected-publications",
+    "views": 1,
+    "change": -0.7933333333333333
+  },
+  {
+    "page": "/studies/phs000220/variables",
+    "views": 1,
+    "change": -0.8277777777777777
+  },
+  {
+    "page": "/studies/phs000240/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000127",
+    "page": "/studies/phs000253",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000128",
+    "page": "/studies/phs000261/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000139",
+    "page": "/studies/phs000285/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs000289/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs000350/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000274",
+    "page": "/studies/phs000368/selected-publications",
     "views": 1,
     "change": null
+  },
+  {
+    "page": "/studies/phs000384",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000406/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000424",
+    "views": 1,
+    "change": -0.6555555555555556
   },
   {
     "page": "/studies/phs000424/",
     "views": 1,
-    "change": null
-  },
-  {
-    "page": "/studies/phs000424/selected-publications",
-    "views": 1,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
     "page": "/studies/phs000424/variables",
     "views": 1,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
-    "page": "/studies/phs000464",
+    "page": "/studies/phs000439/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs000463",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000530",
+    "page": "/studies/phs000464/",
+    "views": 1,
+    "change": -0.7416666666666667
+  },
+  {
+    "page": "/studies/phs000465",
+    "views": 1,
+    "change": -0.7933333333333333
+  },
+  {
+    "page": "/studies/phs000465/",
+    "views": 1,
+    "change": -0.7416666666666667
+  },
+  {
+    "page": "/studies/phs000466/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs000469/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000711",
+    "page": "/studies/phs000471",
     "views": 1,
     "change": null
+  },
+  {
+    "page": "/studies/phs000485",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000536/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000557/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000563/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000647",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000666",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000685/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000703/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000709",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000741/",
+    "views": 1,
+    "change": -0.4833333333333334
   },
   {
     "page": "/studies/phs000748",
     "views": 1,
-    "change": -0.09677419354838712
+    "change": 0.033333333333333215
   },
   {
-    "page": "/studies/phs000820/",
+    "page": "/studies/phs000784/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000794/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000810",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs000832",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs000910",
     "views": 1,
     "change": null
   },
   {
     "page": "/studies/phs000925/",
     "views": 1,
-    "change": null
+    "change": 0.033333333333333215
   },
   {
-    "page": "/studies/phs000925/variables",
+    "page": "/studies/phs000969/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000956/",
+    "page": "/studies/phs000983/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs000971",
-    "views": 1,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs000971/selected-publications",
-    "views": 1,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs000971/variables",
+    "page": "/studies/phs001057/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs001179/selected-publications",
+    "page": "/studies/phs001089",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs001217",
+    "page": "/studies/phs001179/",
+    "views": 1,
+    "change": -0.6555555555555556
+  },
+  {
+    "page": "/studies/phs001200/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001204/variables",
     "views": 1,
     "change": null
   },
   {
     "page": "/studies/phs001218",
     "views": 1,
-    "change": -0.6989247311827957
+    "change": 0.033333333333333215
   },
   {
-    "page": "/studies/phs001247/",
+    "page": "/studies/phs001241",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs001398/",
+    "page": "/studies/phs001281",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs001416/",
+    "page": "/studies/phs001297",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs001420/",
+    "page": "/studies/phs001300",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs001486",
+    "page": "/studies/phs001349",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs001598/",
+    "page": "/studies/phs001349/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs001605",
+    "page": "/studies/phs001349/variables",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs001607",
+    "page": "/studies/phs001374",
     "views": 1,
-    "change": -0.09677419354838712
+    "change": null
+  },
+  {
+    "page": "/studies/phs001427",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001460/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001466/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs001472",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001486/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs001489/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs001497",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001516/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001520",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001553/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001563/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001572/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001592/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001599",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001612",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001628/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs001644",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001644/",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001662",
+    "views": 1,
+    "change": null
   },
   {
     "page": "/studies/phs001683/",
+    "views": 1,
+    "change": 0.033333333333333215
+  },
+  {
+    "page": "/studies/phs001704/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001704/variables",
     "views": 1,
     "change": null
   },
   {
     "page": "/studies/phs001714/",
     "views": 1,
-    "change": -0.09677419354838712
+    "change": 0.033333333333333215
   },
   {
-    "page": "/studies/phs001727",
-    "views": 1,
-    "change": -0.09677419354838712
-  },
-  {
-    "page": "/studies/phs001948",
+    "page": "/studies/phs001728/selected-publications",
     "views": 1,
     "change": null
   },
   {
-    "page": "/studies/phs002808",
+    "page": "/studies/phs001730",
     "views": 1,
-    "change": -0.7741935483870968
+    "change": null
+  },
+  {
+    "page": "/studies/phs001732",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001777/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001804/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001843",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001867/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001897/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001927/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs001931/",
+    "views": 1,
+    "change": -0.6555555555555556
+  },
+  {
+    "page": "/studies/phs001956",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs001957/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002038",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002038/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002038/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002039/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002045/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002064/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002095/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002188",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002196",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002206",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002293",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002305/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002348/",
+    "views": 1,
+    "change": -0.4833333333333334
+  },
+  {
+    "page": "/studies/phs002406",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002409",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002498/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002579/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002611",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002637/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002639",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002683/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002695",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002914",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002944",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs002959/variables",
+    "views": 1,
+    "change": null
   },
   {
     "page": "/studies/phs003045",
     "views": 1,
+    "change": 0.033333333333333215
+  },
+  {
+    "page": "/studies/phs003075/variables",
+    "views": 1,
     "change": null
+  },
+  {
+    "page": "/studies/phs003146/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003151/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003155/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003194/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003309/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003407",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003446/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003454",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003496",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003531/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003620/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003673/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003676",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003809/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003820/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003821",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003833/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003851/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003878/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003892/variables",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs003901",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs004085/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs004115/selected-publications",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/studies/phs004382",
+    "views": 1,
+    "change": null
+  },
+  {
+    "page": "/chat",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/chat",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000007",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000007/selected-publications",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000007/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000090",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000280",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000286",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000516",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000571",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000571/selected-publications",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000667",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000667/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000925",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000925/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000956",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs000956/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs001048",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs001048/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs001228/selected-publications",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs001840",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs001840/selected-publications",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs001840/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs001999",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs003002",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs003600",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs003887",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs003887/selected-publications",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/research/studies/phs003887/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000001",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000006",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000007/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000018",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000019",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000020",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000021",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000086",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000088",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000089",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000090",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000092",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000093",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000094",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000095",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000096",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000100",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000101",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000103",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000125",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000126",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000127",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000128",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000139",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000178",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000178/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000220/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000274",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000298",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000298/selected-publications",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000298/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000424/selected-publications",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000464",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000467/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000470",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000530",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000711",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000820/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000914/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000925",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000925/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000956/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000964",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000971",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000971/selected-publications",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs000971/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001179/selected-publications",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001217",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001217/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001222/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001247/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001287",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001287/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001345",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001398/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001416/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001420/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001486",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001598/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001605",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001607",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001657/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001727",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001735/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001931",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001931/variables",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs001948",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs002363/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs002385",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs002385/",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs002808",
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs002975",
+    "views": 0,
+    "change": -1.0
   },
   {
     "page": "/studies/phs003529",
-    "views": 1,
-    "change": null
+    "views": 0,
+    "change": -1.0
+  },
+  {
+    "page": "/studies/phs003593",
+    "views": 0,
+    "change": -1.0
   },
   {
     "page": "/studies/phs003783",
-    "views": 1,
-    "change": -0.5483870967741935
-  },
-  {
-    "page": "/platforms)",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000179",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000200",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000209",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000209/selected-publications",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000287",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000468",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000471",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000869",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000892",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000921",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000951",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000997",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs000997/selected-publications",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001110",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001175",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001416",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001420",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001489",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001539",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001543",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001545",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001546",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001579",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001598",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001608",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001611",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001612",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001644",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001657",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001662",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001682",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001735",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001913",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs001963",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs002183",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs002183/selected-publications",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs003046",
-    "views": 0,
-    "change": -1.0
-  },
-  {
-    "page": "/studies/phs003543",
     "views": 0,
     "change": -1.0
   }

--- a/analytics/site/index.html
+++ b/analytics/site/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>NCPI Dataset Catalog - Analytics</title>
+    <title>NCPI Data Catalog User Analytics</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/DataBiosphere/findable-ui@fran/873-static-css/static/analytics.css" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/analytics/site/index.html
+++ b/analytics/site/index.html
@@ -50,7 +50,9 @@
         }
 
         .stat-tooltip-text {
-            display: none;
+            visibility: hidden;
+            opacity: 0;
+            pointer-events: none;
             position: absolute;
             background: var(--fui-ink-main);
             color: #fff;
@@ -64,12 +66,15 @@
             margin-bottom: 4px;
             z-index: 10;
             text-align: left;
+            transition: opacity 0.15s;
         }
 
         .stat-tooltip:hover + .stat-tooltip-text,
         .stat-tooltip:focus + .stat-tooltip-text,
         .stat-tooltip-wrapper:hover .stat-tooltip-text {
-            display: block;
+            visibility: visible;
+            opacity: 1;
+            pointer-events: auto;
         }
 
         /* Chart container */

--- a/analytics/site/index.html
+++ b/analytics/site/index.html
@@ -37,6 +37,32 @@
             cursor: help;
             color: var(--fui-ink-light);
             font-size: 0.85em;
+            background: none;
+            border: none;
+            padding: 0;
+            position: relative;
+        }
+
+        .stat-tooltip-text {
+            display: none;
+            position: absolute;
+            background: var(--fui-ink-main);
+            color: #fff;
+            padding: var(--fui-space-8);
+            border-radius: 4px;
+            font: var(--fui-font-body-small-400);
+            width: 240px;
+            left: 50%;
+            transform: translateX(-50%);
+            bottom: 100%;
+            margin-bottom: 4px;
+            z-index: 10;
+            text-align: left;
+        }
+
+        .stat-tooltip:hover + .stat-tooltip-text,
+        .stat-tooltip:focus + .stat-tooltip-text {
+            display: block;
         }
 
         /* Chart container */
@@ -263,18 +289,23 @@
             document.getElementById('generated-date').textContent = meta.generated_at;
         }
 
+        let tooltipIdCounter = 0;
+
         function pctChange(current, prior) {
-            if (prior > 0) return ((current - prior) / prior * 100).toFixed(1);
+            if (prior > 0) return (current - prior) / prior * 100;
             return null;
         }
 
         function statCard(value, label, change, tooltip) {
-            const changeHtml = change != null
-                ? `<div class="stat-change ${change >= 0 ? 'positive' : 'negative'}">${change >= 0 ? '+' : ''}${change}% vs prior month</div>`
+            const formattedChange = change != null ? parseFloat(change.toFixed(1)) : null;
+            const changeHtml = formattedChange != null
+                ? `<div class="stat-change ${formattedChange >= 0 ? 'positive' : 'negative'}">${formattedChange >= 0 ? '+' : ''}${formattedChange.toFixed(1)}% vs prior month</div>`
                 : '';
-            const tooltipHtml = tooltip
-                ? `<span class="stat-tooltip" title="${tooltip}">&#9432;</span>`
-                : '';
+            let tooltipHtml = '';
+            if (tooltip) {
+                const tipId = `stat-tip-${tooltipIdCounter++}`;
+                tooltipHtml = `<button class="stat-tooltip" aria-label="More info about ${label}" aria-describedby="${tipId}" type="button">&#9432;</button><span id="${tipId}" role="tooltip" class="stat-tooltip-text">${tooltip}</span>`;
+            }
             return `
                 <div class="fui-card fui-grid-item-3" style="text-align: center;">
                     <div class="fui-card-content">

--- a/analytics/site/index.html
+++ b/analytics/site/index.html
@@ -33,6 +33,12 @@
         .stat-change.positive { color: var(--fui-success); }
         .stat-change.negative { color: var(--fui-alert); }
 
+        .stat-tooltip {
+            cursor: help;
+            color: var(--fui-ink-light);
+            font-size: 0.85em;
+        }
+
         /* Chart container */
         .chart-container {
             position: relative;
@@ -89,7 +95,7 @@
     <main class="fui-main">
         <!-- Title -->
         <section>
-            <h1 class="fui-heading-large">Analytics</h1>
+            <h1 class="fui-heading-large">NCPI Data Catalog User Analytics</h1>
             <h2 class="fui-heading-small fui-color-ink-light" id="report-month">Loading...</h2>
         </section>
 
@@ -236,7 +242,7 @@
                 const meta = await metaRes.json();
 
                 renderMeta(meta);
-                renderStats(traffic, chat);
+                renderStats(traffic, chat, meta);
                 renderTrafficChart(traffic);
                 renderPageviewsChart(traffic);
                 renderPagesTable(pageviews);
@@ -257,54 +263,68 @@
             document.getElementById('generated-date').textContent = meta.generated_at;
         }
 
-        function renderStats(traffic, chat) {
+        function pctChange(current, prior) {
+            if (prior > 0) return ((current - prior) / prior * 100).toFixed(1);
+            return null;
+        }
+
+        function statCard(value, label, change, tooltip) {
+            const changeHtml = change != null
+                ? `<div class="stat-change ${change >= 0 ? 'positive' : 'negative'}">${change >= 0 ? '+' : ''}${change}% vs prior month</div>`
+                : '';
+            const tooltipHtml = tooltip
+                ? `<span class="stat-tooltip" title="${tooltip}">&#9432;</span>`
+                : '';
+            return `
+                <div class="fui-card fui-grid-item-3" style="text-align: center;">
+                    <div class="fui-card-content">
+                        <div class="stat-value">${value}</div>
+                        <div class="stat-label">${label} ${tooltipHtml}</div>
+                        ${changeHtml}
+                    </div>
+                </div>`;
+        }
+
+        function renderStats(traffic, chat, meta) {
             const latest = traffic[0];
-            const previous = traffic[1];
+            const previous = traffic[1] || {};
 
-            const totalUsers = traffic.reduce((sum, m) => sum + (m.users || 0), 0);
-            const totalPageviews = traffic.reduce((sum, m) => sum + (m.pageviews || 0), 0);
+            const sessions = meta.sessions || {};
+            const engagement = meta.engagement_rate || {};
 
-            let usersChange = 0;
-            let pageviewsChange = 0;
-            if (previous && previous.users > 0) {
-                usersChange = ((latest.users - previous.users) / previous.users * 100).toFixed(1);
-            }
-            if (previous && previous.pageviews > 0) {
-                pageviewsChange = ((latest.pageviews - previous.pageviews) / previous.pageviews * 100).toFixed(1);
-            }
+            const usersChange = pctChange(latest.users, previous.users);
+            const sessionsChange = pctChange(sessions.current, sessions.prior);
+            const pageviewsChange = pctChange(latest.pageviews, previous.pageviews);
+            const engagementChange = pctChange(engagement.current, engagement.prior);
 
-            document.getElementById('stats-grid').innerHTML = `
-                <div class="fui-card fui-grid-item-3" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(latest.users)}</div>
-                        <div class="stat-label">Users (Current Month)</div>
-                        <div class="stat-change ${usersChange >= 0 ? 'positive' : 'negative'}">
-                            ${usersChange >= 0 ? '+' : ''}${usersChange}% vs prior month
-                        </div>
-                    </div>
-                </div>
-                <div class="fui-card fui-grid-item-3" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(latest.pageviews)}</div>
-                        <div class="stat-label">Pageviews (Current Month)</div>
-                        <div class="stat-change ${pageviewsChange >= 0 ? 'positive' : 'negative'}">
-                            ${pageviewsChange >= 0 ? '+' : ''}${pageviewsChange}% vs prior month
-                        </div>
-                    </div>
-                </div>
-                <div class="fui-card fui-grid-item-3" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(totalUsers)}</div>
-                        <div class="stat-label">Total Users (All Time)</div>
-                    </div>
-                </div>
-                <div class="fui-card fui-grid-item-3" style="text-align: center;">
-                    <div class="fui-card-content">
-                        <div class="stat-value">${formatNumber(totalPageviews)}</div>
-                        <div class="stat-label">Total Pageviews (All Time)</div>
-                    </div>
-                </div>
-            `;
+            const engagementDisplay = engagement.current != null
+                ? (engagement.current * 100).toFixed(1) + '%'
+                : '-';
+
+            const [year, month] = meta.current_month.split('-');
+            const monthName = new Date(year, month - 1).toLocaleString('default', { month: 'long' });
+
+            document.getElementById('stats-grid').innerHTML =
+                statCard(
+                    formatNumber(latest.users), 'Users',
+                    usersChange,
+                    `Total number of unique individuals who visited the site during ${monthName}.`
+                ) +
+                statCard(
+                    formatNumber(sessions.current || 0), 'User Sessions',
+                    sessionsChange,
+                    `Total number of visits to the site during ${monthName}. A single user can have multiple sessions.`
+                ) +
+                statCard(
+                    formatNumber(latest.pageviews), 'Pageviews',
+                    pageviewsChange,
+                    `Total number of pages viewed during ${monthName}. This includes repeated views of the same page.`
+                ) +
+                statCard(
+                    engagementDisplay, 'Engagement Rate',
+                    engagementChange,
+                    `Percentage of sessions during ${monthName} where users actively engaged with the site (e.g., stayed longer, viewed multiple pages, or triggered events). Higher is better.`
+                );
 
             // Render event stats at the bottom
             const chatChange = chat.change != null ? (chat.change * 100).toFixed(1) : null;

--- a/analytics/site/index.html
+++ b/analytics/site/index.html
@@ -23,6 +23,7 @@
             font: var(--fui-font-body-small-400);
             color: var(--fui-ink-light);
             margin-top: var(--fui-space-4);
+            position: relative;
         }
 
         .stat-change {

--- a/analytics/site/index.html
+++ b/analytics/site/index.html
@@ -33,6 +33,12 @@
         .stat-change.positive { color: var(--fui-success); }
         .stat-change.negative { color: var(--fui-alert); }
 
+        .stat-tooltip-wrapper {
+            position: relative;
+            display: inline-block;
+            vertical-align: middle;
+        }
+
         .stat-tooltip {
             cursor: help;
             color: var(--fui-ink-light);
@@ -40,7 +46,6 @@
             background: none;
             border: none;
             padding: 0;
-            position: relative;
         }
 
         .stat-tooltip-text {
@@ -61,7 +66,8 @@
         }
 
         .stat-tooltip:hover + .stat-tooltip-text,
-        .stat-tooltip:focus + .stat-tooltip-text {
+        .stat-tooltip:focus + .stat-tooltip-text,
+        .stat-tooltip-wrapper:hover .stat-tooltip-text {
             display: block;
         }
 
@@ -304,7 +310,7 @@
             let tooltipHtml = '';
             if (tooltip) {
                 const tipId = `stat-tip-${tooltipIdCounter++}`;
-                tooltipHtml = `<button class="stat-tooltip" aria-label="More info about ${label}" aria-describedby="${tipId}" type="button">&#9432;</button><span id="${tipId}" role="tooltip" class="stat-tooltip-text">${tooltip}</span>`;
+                tooltipHtml = `<span class="stat-tooltip-wrapper"><button class="stat-tooltip" aria-label="More info about ${label}" aria-describedby="${tipId}" type="button">&#9432;</button><span id="${tipId}" role="tooltip" class="stat-tooltip-text">${tooltip}</span></span>`;
             }
             return `
                 <div class="fui-card fui-grid-item-3" style="text-align: center;">


### PR DESCRIPTION
## Summary
- Update analytics static site for April 2026 reporting period
- Add User Sessions and Engagement Rate stat cards to match data-browser, anvil-portal, and data-portal analytics pages
- Fix bug in `generate_static_site.py` where `filter_selected` export used incorrect column names (`Total Events` → `Event Count`)
- Update page heading to "NCPI Data Catalog User Analytics"

Closes #352

## Test plan
- [ ] Review the analytics page at the deployed GitHub Pages URL
- [ ] Verify the four stat cards display correctly: Users, User Sessions, Pageviews, Engagement Rate
- [ ] Verify tooltips appear on each stat card label
- [ ] Verify April 2026 data is shown (check month heading and meta.json)
- [ ] Verify charts and tables still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)