### PR TITLE
chore: disable duos access request option for ncpi studies (#355)

### DIFF
--- a/app/components/RequestAccess/utils.ts
+++ b/app/components/RequestAccess/utils.ts
@@ -1,6 +1,8 @@
 import { ListItemTextProps } from "@mui/material";
 import { NCPICatalogStudy } from "../../apis/catalog/ncpi-catalog/common/entities";
 
+const DUOS_ENABLED = false;
+
 /**
  * Generates a list of request access menu options based on the provided study.
  * This function extracts identifiers (DUOS URL and dbGaP ID) from the study and returns an array of menu option objects.
@@ -16,7 +18,7 @@ export function getRequestAccessOptions(
 
   // Build up the request access options based on the presence of dbGaP ID and DUOS URL.
   const options = [];
-  if (duosUrl) {
+  if (DUOS_ENABLED && duosUrl) {
     // If a DUOS ID is present, add a menu option for DUOS.
     options.push({
       href: duosUrl,

--- a/app/components/RequestAccess/utils.ts
+++ b/app/components/RequestAccess/utils.ts
@@ -1,11 +1,12 @@
 import { ListItemTextProps } from "@mui/material";
 import { NCPICatalogStudy } from "../../apis/catalog/ncpi-catalog/common/entities";
 
+// DUOS access request option temporarily disabled (see #355). Flip to true to re-enable.
 const DUOS_ENABLED = false;
 
 /**
  * Generates a list of request access menu options based on the provided study.
- * This function extracts identifiers (DUOS URL and dbGaP ID) from the study and returns an array of menu option objects.
+ * This function extracts identifiers (DUOS URL and dbGaP ID) from the study and returns an array of menu option objects (the DUOS option is gated by DUOS_ENABLED).
  * Each menu option contains a link `href` and title `primary` and description text `secondary`, to be used in Material UI's `MenuItem` and `ListItemText` component.
  * @param ncpiCatalogStudy - The study object containing identifiers for DUOS and dbGaP.
  * @returns menu option objects with `href`, `primary`, and `secondary` properties.


### PR DESCRIPTION
## Summary

- Disable the DUOS access request option on study detail pages without removing the underlying code.
- Adds a `DUOS_ENABLED = false` constant in `app/components/RequestAccess/utils.ts` and guards the existing `if (duosUrl)` branch with it, so the option can be re-enabled by flipping the flag.
- dbGaP request access option is unchanged.

Closes #355

## Test plan

- [x] Verify the DUOS option no longer appears in the "Request Access" menu on a study that has a `duosUrl` (e.g. an NHGRI-sponsored study)
- [x] Verify the dbGaP option still appears for studies with a `dbGapId`
- [ ] Verify a study with neither `duosUrl` nor `dbGapId` renders the same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2547" height="1011" alt="image" src="https://github.com/user-attachments/assets/816da301-b8e2-49f2-9692-6e9d1c6fc9b5" />

<img width="2549" height="1048" alt="image" src="https://github.com/user-attachments/assets/7869df2a-0b30-4b14-a77f-1609ac995b30" />
