### PR TITLE
feat: add bot traffic filtering and engaged sessions metric

### DIFF
--- a/analytics/generate_static_site.py
+++ b/analytics/generate_static_site.py
@@ -210,8 +210,9 @@ def fetch_data(ga_authentication):
     )
     sessions_current = int(df_sessions_current[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_current) > 0 else 0
     sessions_prior = int(df_sessions_prior[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_prior) > 0 else 0
-    engaged_sessions_current = int(df_sessions_current[METRIC_ENGAGED_SESSIONS["alias"]].sum()) if len(df_sessions_current) > 0 else 0
-    engaged_sessions_prior = int(df_sessions_prior[METRIC_ENGAGED_SESSIONS["alias"]].sum()) if len(df_sessions_prior) > 0 else 0
+    engaged_col = METRIC_ENGAGED_SESSIONS["alias"]
+    engaged_sessions_current = int(df_sessions_current[engaged_col].sum()) if len(df_sessions_current) > 0 and engaged_col in df_sessions_current.columns else 0
+    engaged_sessions_prior = int(df_sessions_prior[engaged_col].sum()) if len(df_sessions_prior) > 0 and engaged_col in df_sessions_prior.columns else 0
     _eng_current = df_sessions_current[METRIC_ENGAGEMENT_RATE["alias"]].mean() if len(df_sessions_current) > 0 else None
     _eng_prior = df_sessions_prior[METRIC_ENGAGEMENT_RATE["alias"]].mean() if len(df_sessions_prior) > 0 else None
     engagement_current = float(_eng_current) if _eng_current is not None and not pd.isna(_eng_current) else None

--- a/analytics/generate_static_site.py
+++ b/analytics/generate_static_site.py
@@ -18,6 +18,7 @@ The script will:
 
 import os
 import json
+import re
 from datetime import datetime
 
 import pandas as pd
@@ -93,6 +94,27 @@ METRIC_ENGAGEMENT_RATE = {
     "alias": "Engagement Rate",
 }
 
+METRIC_ENGAGED_SESSIONS = {
+    "id": "engagedSessions",
+    "alias": "Engaged Sessions",
+}
+
+# Regex matching page paths that are clearly not real pages (bot probes,
+# broken markdown links, asset requests, etc.).
+SUSPICIOUS_PAGE_PATH_RE = re.compile(
+    r"("
+    r"^/?\].*"             # broken markdown links e.g. /](https://...)
+    r"|.*https?://.*"      # concatenated URLs e.g. /overview/securityhttps://...
+    r"|^/[^/]*@[^/]*"     # email-as-path e.g. /help@lists...
+    r"|^//.*"              # double-slash probes e.g. //checkout/
+    r"|^/[^/]*\.[^/]+$"   # file extensions at root e.g. /robots.txt, /favicon-32x32.png
+    r"|^/feed$"            # RSS probes
+    r"|^/\).*"             # broken parens e.g. /), /).
+    r"|^/[^/]*\).*"       # broken parens e.g. /events)
+    r"|^/docs(-\w+)?/"     # CMS probes e.g. /docs/, /docs-EN/
+    r")"
+)
+
 
 def fetch_data(ga_authentication):
     """Fetch analytics data using the analytics package."""
@@ -143,6 +165,14 @@ def fetch_data(ga_authentication):
         end_date_prior,
     )
 
+    if df_pageviews is not None and len(df_pageviews) > 0:
+        page_col = "Page Path"
+        suspicious_mask = df_pageviews[page_col].str.match(SUSPICIOUS_PAGE_PATH_RE, na=False)
+        n_suspicious = suspicious_mask.sum()
+        if n_suspicious > 0:
+            df_pageviews = df_pageviews[~suspicious_mask]
+            print(f"  Filtered {n_suspicious} suspicious page path(s)")
+
     print("Fetching outbound links data...")
     df_outbound = elements.get_outbound_links_change(
         ncpi_catalog_params,
@@ -173,13 +203,15 @@ def fetch_data(ga_authentication):
 
     print("Fetching sessions and engagement data...")
     df_sessions_current = get_data_df_from_fields(
-        [METRIC_SESSIONS, METRIC_ENGAGEMENT_RATE], [], **ncpi_catalog_params,
+        [METRIC_SESSIONS, METRIC_ENGAGED_SESSIONS, METRIC_ENGAGEMENT_RATE], [], **ncpi_catalog_params,
     )
     df_sessions_prior = get_data_df_from_fields(
-        [METRIC_SESSIONS, METRIC_ENGAGEMENT_RATE], [], **ncpi_catalog_params_prior,
+        [METRIC_SESSIONS, METRIC_ENGAGED_SESSIONS, METRIC_ENGAGEMENT_RATE], [], **ncpi_catalog_params_prior,
     )
     sessions_current = int(df_sessions_current[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_current) > 0 else 0
     sessions_prior = int(df_sessions_prior[METRIC_SESSIONS["alias"]].sum()) if len(df_sessions_prior) > 0 else 0
+    engaged_sessions_current = int(df_sessions_current[METRIC_ENGAGED_SESSIONS["alias"]].sum()) if len(df_sessions_current) > 0 else 0
+    engaged_sessions_prior = int(df_sessions_prior[METRIC_ENGAGED_SESSIONS["alias"]].sum()) if len(df_sessions_prior) > 0 else 0
     _eng_current = df_sessions_current[METRIC_ENGAGEMENT_RATE["alias"]].mean() if len(df_sessions_current) > 0 else None
     _eng_prior = df_sessions_prior[METRIC_ENGAGEMENT_RATE["alias"]].mean() if len(df_sessions_prior) > 0 else None
     engagement_current = float(_eng_current) if _eng_current is not None and not pd.isna(_eng_current) else None
@@ -191,6 +223,10 @@ def fetch_data(ga_authentication):
         "sessions": {
             "current": sessions_current,
             "prior": sessions_prior,
+        },
+        "engaged_sessions": {
+            "current": engaged_sessions_current,
+            "prior": engaged_sessions_prior,
         },
         "engagement_rate": {
             "current": engagement_current,
@@ -312,6 +348,7 @@ def export_data(data, output_dir="site/data"):
         "prior_month_end": dates.get("end_prior", ""),
         "analytics_start": ANALYTICS_START,
         "sessions": data.get("sessions", {}),
+        "engaged_sessions": data.get("engaged_sessions", {}),
         "engagement_rate": data.get("engagement_rate", {}),
     }
 

--- a/analytics/requirements.txt
+++ b/analytics/requirements.txt
@@ -1,4 +1,4 @@
--e "git+https://github.com/DataBiosphere/data-browser.git@analytics-4.3.0#egg=analytics&subdirectory=analytics/analytics_package"
+-e "git+https://github.com/DataBiosphere/data-browser.git@main#egg=analytics&subdirectory=analytics/analytics_package"
 cachetools==5.5.1
 certifi==2025.1.31
 charset-normalizer==3.4.1

--- a/analytics/site/data/meta.json
+++ b/analytics/site/data/meta.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06 10:49:24",
+  "generated_at": "2026-05-27 16:51:02",
   "current_month": "2026-04",
   "current_month_start": "2026-04-01",
   "current_month_end": "2026-04-30",
@@ -9,6 +9,10 @@
   "sessions": {
     "current": 514,
     "prior": 470
+  },
+  "engaged_sessions": {
+    "current": 98,
+    "prior": 110
   },
   "engagement_rate": {
     "current": 0.19066147859922178,

--- a/analytics/site/index.html
+++ b/analytics/site/index.html
@@ -337,7 +337,8 @@
             const engagement = meta.engagement_rate || {};
 
             const usersChange = pctChange(latest.users, previous.users);
-            const engagedSessionsChange = pctChange(engagedSessions.current, engagedSessions.prior);
+            const sessionsSource = engagedSessions.current != null ? engagedSessions : sessions;
+            const engagedSessionsChange = pctChange(sessionsSource.current, sessionsSource.prior);
             const pageviewsChange = pctChange(latest.pageviews, previous.pageviews);
             const engagementChange = pctChange(engagement.current, engagement.prior);
 
@@ -355,7 +356,7 @@
                     `Total number of unique individuals who visited the site during ${monthName}.`
                 ) +
                 statCard(
-                    formatNumber(engagedSessions.current || sessions.current || 0), 'Engaged Sessions',
+                    formatNumber(engagedSessions.current != null ? engagedSessions.current : (sessions.current || 0)), 'Engaged Sessions',
                     engagedSessionsChange,
                     `Sessions where users actively engaged with the site during ${monthName} (stayed 10+ seconds, viewed 2+ pages, or triggered a conversion). <a href="https://support.google.com/analytics/answer/11109416" target="_blank" rel="noopener noreferrer">Learn more</a>.`
                 ) +

--- a/analytics/site/index.html
+++ b/analytics/site/index.html
@@ -333,10 +333,11 @@
             const previous = traffic[1] || {};
 
             const sessions = meta.sessions || {};
+            const engagedSessions = meta.engaged_sessions || {};
             const engagement = meta.engagement_rate || {};
 
             const usersChange = pctChange(latest.users, previous.users);
-            const sessionsChange = pctChange(sessions.current, sessions.prior);
+            const engagedSessionsChange = pctChange(engagedSessions.current, engagedSessions.prior);
             const pageviewsChange = pctChange(latest.pageviews, previous.pageviews);
             const engagementChange = pctChange(engagement.current, engagement.prior);
 
@@ -354,9 +355,9 @@
                     `Total number of unique individuals who visited the site during ${monthName}.`
                 ) +
                 statCard(
-                    formatNumber(sessions.current || 0), 'User Sessions',
-                    sessionsChange,
-                    `Total number of visits to the site during ${monthName}. A single user can have multiple sessions.`
+                    formatNumber(engagedSessions.current || sessions.current || 0), 'Engaged Sessions',
+                    engagedSessionsChange,
+                    `Sessions where users actively engaged with the site during ${monthName} (stayed 10+ seconds, viewed 2+ pages, or triggered a conversion). <a href="https://support.google.com/analytics/answer/11109416" target="_blank" rel="noopener noreferrer">Learn more</a>.`
                 ) +
                 statCard(
                     formatNumber(latest.pageviews), 'Pageviews',


### PR DESCRIPTION
## Ticket
Closes #354

## Summary
- Add suspicious page path regex filter to remove bot/malformed paths from pageviews
- Add engaged sessions metric (GA4 `engagedSessions`) to replace "User Sessions" in the stats card
- Update analytics package dependency to data-browser main
- Regenerate static analytics site with updated data

Note: This repo has its own custom `generate_static_site.py`, so the bot filtering and engaged sessions changes were applied manually (rather than coming from the shared analytics package).

## Test plan
- [x] Regenerated site locally and verified engaged sessions metric appears
- [x] Verified template shows "Engaged Sessions" instead of "User Sessions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)