### PR TITLE
feat: add session store abstraction + in-memory conversation store (#360)

### DIFF
--- a/backend/concept_search/models.py
+++ b/backend/concept_search/models.py
@@ -253,3 +253,19 @@ class QueryModel(BaseModel):
         description="Clarification message from the agents when the query "
         "is vague, ambiguous, or partially unresolved. None on success.",
     )
+
+
+# --- Conversation / session models ---
+
+
+class ConversationMessage(BaseModel):
+    """A single text turn in the conversation history.
+
+    Only the user/assistant text is persisted — never the per-turn tool
+    scratchpad. See ``session_store.SessionState``.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    content: str = Field(description="The message text.")
+    role: Literal["user", "assistant"] = Field(description="Who produced the message.")

--- a/backend/concept_search/session_store.py
+++ b/backend/concept_search/session_store.py
@@ -1,0 +1,161 @@
+"""Swappable conversation/session stores.
+
+Provides a ``SessionStore`` protocol and an ``InMemorySessionStore``
+implementation. A future DynamoDB-backed store (AWS-native, native TTL)
+implements the same protocol — see issue #360.
+
+The persisted ``SessionState`` is deliberately **lean**: the user/assistant
+text turns plus the current resolved ``QueryModel``. The per-turn tool
+scratchpad (concept-search candidates, study lookups) is never handed to the
+store — the agent loop discards it when a turn ends. There is no trimming
+step; the lean shape is the schema.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+from .models import ConversationMessage, QueryModel
+
+
+class SessionState(BaseModel):
+    """Lean persisted conversation state — text turns plus the resolved query.
+
+    Excludes the per-turn tool scratchpad by construction: the agent loop hands
+    the store only the user/assistant text and the resulting ``QueryModel``.
+    Pending disambiguation already lives inside ``QueryModel`` (via each
+    mention's ``disambiguation`` list), so no separate field is needed.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    messages: list[ConversationMessage] = Field(default_factory=list)
+    query: QueryModel | None = None
+
+
+@runtime_checkable
+class SessionStore(Protocol):
+    """Protocol for conversation-state backends.
+
+    Full-state semantics: callers read the whole ``SessionState``, mutate it,
+    and write it back. This mirrors a single DynamoDB item replaced by
+    ``PutItem``, so every backend behaves identically.
+    """
+
+    async def get(self, session_id: str) -> SessionState | None:
+        """Return the stored state for *session_id*, or None if absent/expired."""
+        ...
+
+    async def save(self, session_id: str, state: SessionState) -> None:
+        """Persist *state* for *session_id*, replacing any existing state."""
+        ...
+
+    async def delete(self, session_id: str) -> None:
+        """Remove any state for *session_id*. No-op if absent."""
+        ...
+
+
+class InMemorySessionStore:
+    """Process-local dict-backed ``SessionStore`` with optional TTL eviction.
+
+    Used for unit tests, evals, and local dev with zero AWS dependency. The
+    optional ``ttl_seconds`` mirrors DynamoDB native TTL so expiry behaviour
+    matches across backends; expired entries are dropped lazily on access.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float | None = None,
+        _now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Create an empty store.
+
+        Args:
+            ttl_seconds: Seconds before a saved session expires. None disables expiry.
+            _now: Monotonic clock, injectable so TTL is testable without sleeping.
+        """
+        self._ttl_seconds = ttl_seconds
+        self._now = _now
+        self._lock = threading.Lock()
+        # session_id -> (state, expires_at). expires_at is None when TTL is off.
+        self._store: dict[str, tuple[SessionState, float | None]] = {}
+
+    async def get(self, session_id: str) -> SessionState | None:
+        """Return a deep copy of the stored state, or None if absent/expired."""
+        with self._lock:
+            entry = self._store.get(session_id)
+            if entry is None:
+                return None
+            state, expires_at = entry
+            if expires_at is not None and self._now() >= expires_at:
+                del self._store[session_id]
+                return None
+            return state.model_copy(deep=True)
+
+    async def save(self, session_id: str, state: SessionState) -> None:
+        """Store a deep copy of *state*, replacing any existing entry."""
+        with self._lock:
+            expires_at = None if self._ttl_seconds is None else self._now() + self._ttl_seconds
+            self._store[session_id] = (state.model_copy(deep=True), expires_at)
+
+    async def delete(self, session_id: str) -> None:
+        """Remove any state for *session_id*. No-op if absent."""
+        with self._lock:
+            self._store.pop(session_id, None)
+
+
+_DEFAULT_TTL_SECONDS = 86400.0
+
+_session_store: SessionStore | None = None
+_lock = threading.Lock()
+
+
+def _resolve_ttl_seconds() -> float:
+    """Resolve the in-memory store TTL from ``SESSION_TTL_SECONDS``.
+
+    An unset or empty value falls back to the default. A non-empty value that
+    is not a number is a misconfiguration and fails loudly.
+
+    Returns:
+        The TTL in seconds.
+
+    Raises:
+        ValueError: If ``SESSION_TTL_SECONDS`` is set to a non-numeric value.
+    """
+    raw = os.getenv("SESSION_TTL_SECONDS", "")
+    if not raw.strip():
+        return _DEFAULT_TTL_SECONDS
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid SESSION_TTL_SECONDS: {raw!r} (must be a number of seconds)"
+        ) from exc
+
+
+def get_session_store() -> SessionStore:
+    """Return the process-wide session store, constructing it on first use.
+
+    The backend is selected by ``SESSION_STORE_BACKEND`` (default ``"memory"``).
+    The DynamoDB backend is added in a follow-up ticket.
+
+    Returns:
+        The singleton ``SessionStore`` for this process.
+    """
+    global _session_store  # noqa: PLW0603
+    with _lock:
+        if _session_store is None:
+            backend = os.getenv("SESSION_STORE_BACKEND", "memory")
+            if backend == "memory":
+                _session_store = InMemorySessionStore(ttl_seconds=_resolve_ttl_seconds())
+            else:
+                raise ValueError(f"Unknown SESSION_STORE_BACKEND: {backend!r}")
+    return _session_store

--- a/backend/concept_search/session_store.py
+++ b/backend/concept_search/session_store.py
@@ -13,6 +13,7 @@ step; the lean shape is the schema.
 
 from __future__ import annotations
 
+import math
 import os
 import threading
 import time
@@ -122,23 +123,31 @@ def _resolve_ttl_seconds() -> float:
     """Resolve the in-memory store TTL from ``SESSION_TTL_SECONDS``.
 
     An unset or empty value falls back to the default. A non-empty value that
-    is not a number is a misconfiguration and fails loudly.
+    is not a positive, finite number is a misconfiguration and fails loudly
+    (``"nan"``/``"inf"`` would silently disable expiry, a negative value would
+    expire every session immediately).
 
     Returns:
         The TTL in seconds.
 
     Raises:
-        ValueError: If ``SESSION_TTL_SECONDS`` is set to a non-numeric value.
+        ValueError: If ``SESSION_TTL_SECONDS`` is set but is not a positive,
+            finite number.
     """
     raw = os.getenv("SESSION_TTL_SECONDS", "")
     if not raw.strip():
         return _DEFAULT_TTL_SECONDS
     try:
-        return float(raw)
+        ttl = float(raw)
     except ValueError as exc:
         raise ValueError(
-            f"Invalid SESSION_TTL_SECONDS: {raw!r} (must be a number of seconds)"
+            f"Invalid SESSION_TTL_SECONDS: {raw!r} (must be a positive number of seconds)"
         ) from exc
+    if not math.isfinite(ttl) or ttl <= 0:
+        raise ValueError(
+            f"Invalid SESSION_TTL_SECONDS: {raw!r} (must be a positive number of seconds)"
+        )
+    return ttl
 
 
 def get_session_store() -> SessionStore:

--- a/backend/tests/test_session_store.py
+++ b/backend/tests/test_session_store.py
@@ -197,9 +197,10 @@ def test_factory_empty_ttl_uses_default(_reset_factory_singleton) -> None:
     assert store._ttl_seconds == 86400.0
 
 
-def test_factory_invalid_ttl_raises(_reset_factory_singleton) -> None:
-    """A non-numeric SESSION_TTL_SECONDS fails loudly."""
+@pytest.mark.parametrize("bad_value", ["30s", "nan", "inf", "-5", "0"])
+def test_factory_invalid_ttl_raises(_reset_factory_singleton, bad_value: str) -> None:
+    """A non-numeric, non-finite, or non-positive SESSION_TTL_SECONDS fails loudly."""
     os.environ.pop("SESSION_STORE_BACKEND", None)
-    os.environ["SESSION_TTL_SECONDS"] = "30s"
+    os.environ["SESSION_TTL_SECONDS"] = bad_value
     with pytest.raises(ValueError, match="Invalid SESSION_TTL_SECONDS"):
         get_session_store()

--- a/backend/tests/test_session_store.py
+++ b/backend/tests/test_session_store.py
@@ -1,0 +1,205 @@
+"""Unit tests for the conversation/session store abstraction."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from concept_search import session_store as session_store_module
+from concept_search.models import ConversationMessage, QueryModel, ResolvedMention
+from concept_search.session_store import (
+    InMemorySessionStore,
+    SessionState,
+    SessionStore,
+    get_session_store,
+)
+
+
+class _Clock:
+    """A manually advanced monotonic clock for TTL tests."""
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _make_state(text: str = "glucose studies") -> SessionState:
+    """Build a SessionState with one user turn and a minimal query."""
+    return SessionState(
+        messages=[ConversationMessage(role="user", content=text)],
+        query=QueryModel(
+            intent="study",
+            mentions=[
+                ResolvedMention(
+                    facet="measurement",
+                    original_text="glucose",
+                    values=["phenx:blood_glucose"],
+                )
+            ],
+        ),
+    )
+
+
+@pytest.mark.asyncio()
+async def test_save_get_round_trip() -> None:
+    """Saving then getting returns equal state."""
+    store = InMemorySessionStore()
+    state = _make_state()
+    await store.save("sess1", state)
+    got = await store.get("sess1")
+    assert got == state
+
+
+@pytest.mark.asyncio()
+async def test_get_unknown_returns_none() -> None:
+    """Getting an unknown session id returns None."""
+    store = InMemorySessionStore()
+    assert await store.get("nope") is None
+
+
+@pytest.mark.asyncio()
+async def test_sessions_are_isolated() -> None:
+    """Distinct session ids hold independent state."""
+    store = InMemorySessionStore()
+    a = _make_state("glucose studies")
+    b = _make_state("asthma studies")
+    await store.save("a", a)
+    await store.save("b", b)
+    assert await store.get("a") == a
+    assert await store.get("b") == b
+
+
+@pytest.mark.asyncio()
+async def test_save_replaces_existing() -> None:
+    """A second save for the same id replaces the first."""
+    store = InMemorySessionStore()
+    await store.save("sess1", _make_state("first"))
+    await store.save("sess1", _make_state("second"))
+    got = await store.get("sess1")
+    assert got is not None
+    assert got.messages[0].content == "second"
+
+
+@pytest.mark.asyncio()
+async def test_delete_removes_session() -> None:
+    """Delete removes the session; a subsequent get returns None."""
+    store = InMemorySessionStore()
+    await store.save("sess1", _make_state())
+    await store.delete("sess1")
+    assert await store.get("sess1") is None
+
+
+@pytest.mark.asyncio()
+async def test_delete_unknown_is_noop() -> None:
+    """Deleting an unknown session id does not raise."""
+    store = InMemorySessionStore()
+    await store.delete("nope")
+
+
+@pytest.mark.asyncio()
+async def test_returned_state_is_isolated_copy() -> None:
+    """Mutating a returned state does not corrupt stored data."""
+    store = InMemorySessionStore()
+    await store.save("sess1", _make_state())
+    got = await store.get("sess1")
+    assert got is not None
+    got.messages.append(ConversationMessage(role="assistant", content="injected"))
+
+    again = await store.get("sess1")
+    assert again is not None
+    assert len(again.messages) == 1
+
+
+@pytest.mark.asyncio()
+async def test_saved_state_is_snapshot() -> None:
+    """Mutating the passed-in state after save does not corrupt stored data."""
+    store = InMemorySessionStore()
+    state = _make_state()
+    await store.save("sess1", state)
+    state.messages.append(ConversationMessage(role="assistant", content="injected"))
+
+    got = await store.get("sess1")
+    assert got is not None
+    assert len(got.messages) == 1
+
+
+@pytest.mark.asyncio()
+async def test_ttl_expires_session() -> None:
+    """A session is returned before its TTL and dropped after."""
+    clock = _Clock()
+    store = InMemorySessionStore(ttl_seconds=100.0, _now=clock)
+    await store.save("sess1", _make_state())
+
+    clock.advance(99.0)
+    assert await store.get("sess1") is not None
+
+    clock.advance(2.0)  # now past the 100s TTL
+    assert await store.get("sess1") is None
+    # Entry is dropped, not just hidden.
+    assert "sess1" not in store._store
+
+
+@pytest.mark.asyncio()
+async def test_no_ttl_never_expires() -> None:
+    """With TTL disabled, state persists regardless of clock movement."""
+    clock = _Clock()
+    store = InMemorySessionStore(ttl_seconds=None, _now=clock)
+    await store.save("sess1", _make_state())
+    clock.advance(1_000_000.0)
+    assert await store.get("sess1") is not None
+
+
+@pytest.fixture()
+def _reset_factory_singleton():
+    """Reset the module-level singleton and backend env around a test."""
+    saved_env = {
+        key: os.environ.get(key) for key in ("SESSION_STORE_BACKEND", "SESSION_TTL_SECONDS")
+    }
+    session_store_module._session_store = None
+    yield
+    session_store_module._session_store = None
+    for key, value in saved_env.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def test_factory_defaults_to_in_memory_singleton(_reset_factory_singleton) -> None:
+    """Default backend is in-memory and the factory returns a singleton."""
+    os.environ.pop("SESSION_STORE_BACKEND", None)
+    os.environ.pop("SESSION_TTL_SECONDS", None)
+    store = get_session_store()
+    assert isinstance(store, InMemorySessionStore)
+    assert isinstance(store, SessionStore)
+    assert get_session_store() is store
+
+
+def test_factory_unknown_backend_raises(_reset_factory_singleton) -> None:
+    """An unknown backend selector raises ValueError."""
+    os.environ["SESSION_STORE_BACKEND"] = "redis"
+    with pytest.raises(ValueError, match="Unknown SESSION_STORE_BACKEND"):
+        get_session_store()
+
+
+def test_factory_empty_ttl_uses_default(_reset_factory_singleton) -> None:
+    """An empty SESSION_TTL_SECONDS falls back to the default TTL."""
+    os.environ.pop("SESSION_STORE_BACKEND", None)
+    os.environ["SESSION_TTL_SECONDS"] = ""
+    store = get_session_store()
+    assert isinstance(store, InMemorySessionStore)
+    assert store._ttl_seconds == 86400.0
+
+
+def test_factory_invalid_ttl_raises(_reset_factory_singleton) -> None:
+    """A non-numeric SESSION_TTL_SECONDS fails loudly."""
+    os.environ.pop("SESSION_STORE_BACKEND", None)
+    os.environ["SESSION_TTL_SECONDS"] = "30s"
+    with pytest.raises(ValueError, match="Invalid SESSION_TTL_SECONDS"):
+        get_session_store()


### PR DESCRIPTION
## Summary

Foundational storage seam for the upcoming conversation-aware **agent loop** (the pivot away from the Extract→Resolve→Structure→Router state machine). Adds a `SessionStore` abstraction with an in-memory implementation so the agent-loop work can be built, unit-tested, eval'd, and run locally with **zero AWS dependency**. Conversation state will eventually live in **DynamoDB** (AWS-native, serverless, native TTL); that adapter is a separate ticket.

Closes #360.

## What's included

- **`ConversationMessage`** (`models.py`) — a single user/assistant text turn.
- **`SessionState`** — the lean persisted shape: text `messages` + the resolved `QueryModel`. Excludes the per-turn tool scratchpad by construction (pending disambiguation already lives inside `QueryModel`).
- **`SessionStore`** — async, full-state `Protocol` (`get` / `save` / `delete`), mirroring the existing `StudyStore` protocol precedent. Full-state semantics match DynamoDB's single-item `PutItem`.
- **`InMemorySessionStore`** — dict-backed; **deep-copies on save and get** so callers can't corrupt stored state; optional `ttl_seconds` lazy eviction (mirrors DynamoDB native TTL) with an injectable clock for testing.
- **`get_session_store()`** — env-selected singleton (`SESSION_STORE_BACKEND`, default `memory`); defensive `SESSION_TTL_SECONDS` parsing (unset/empty → default `86400`, non-numeric → raises with a clear message).

## Out of scope (follow-up tickets)

- DynamoDB adapter (`amazon/dynamodb-local` + `moto` tests)
- The agent loop / single-model router
- `/search` endpoint + frontend `session_id` plumbing

The store is **not** wired into the live endpoint yet.

## Testing

- `uv run python -m pytest tests/test_session_store.py` → **14 passed** (round-trip, isolation, replace, delete, both deep-copy directions, TTL expiry/no-TTL, factory singleton + default/empty/invalid TTL parsing).
- Full backend suite green; `make lint` and `make format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
