### PR TITLE
refactor: extract execute_query_model + query-structure helper from /search

### DIFF
--- a/backend/concept_search/api.py
+++ b/backend/concept_search/api.py
@@ -41,7 +41,12 @@ from .models import (
 from .pipeline import pipeline_cache, run_pipeline
 from .rate_limit import RateLimiter
 from .resolve_agent import resolve_cache
-from .response_summary import build_message, build_query_structure, diagnose_empty_results
+from .response_summary import (
+    QueryStructure,
+    build_message,
+    build_query_structure,
+    diagnose_empty_results,
+)
 from .router_agent import run_router
 from .search_execution import execute_query_model
 
@@ -207,7 +212,7 @@ def _build_dbgap_study_url(study_id: str) -> str:
     return f"https://dbgap.ncbi.nlm.nih.gov/study/{study_id}"
 
 
-def _to_api_query_structure(query_structure: object) -> ApiQueryStructure | None:
+def _to_api_query_structure(query_structure: QueryStructure | None) -> ApiQueryStructure | None:
     """Convert an internal QueryStructure to the API model (or None)."""
     if query_structure is None:
         return None

--- a/backend/concept_search/api.py
+++ b/backend/concept_search/api.py
@@ -30,9 +30,7 @@ from .api_models import (
 from .api_models import QueryClause as ApiQueryClause
 from .api_models import QueryStructure as ApiQueryStructure
 from .index import get_index
-from .mention_constraints import split_mentions as _split_mentions
 from .models import (
-    Facet,
     QueryModel,
     ResolvedMention,
     RouteRemove,
@@ -45,6 +43,7 @@ from .rate_limit import RateLimiter
 from .resolve_agent import resolve_cache
 from .response_summary import build_message, build_query_structure, diagnose_empty_results
 from .router_agent import run_router
+from .search_execution import execute_query_model
 
 # Structured JSON logging to stdout (picked up by CloudWatch via App Runner)
 logging.basicConfig(
@@ -206,6 +205,25 @@ def _build_dbgap_study_url(study_id: str) -> str:
         Full URL to the study page on dbGaP.
     """
     return f"https://dbgap.ncbi.nlm.nih.gov/study/{study_id}"
+
+
+def _to_api_query_structure(query_structure: object) -> ApiQueryStructure | None:
+    """Convert an internal QueryStructure to the API model (or None)."""
+    if query_structure is None:
+        return None
+    return ApiQueryStructure(
+        clauses=[
+            ApiQueryClause(
+                exclude=c.exclude,
+                facet=c.facet,
+                labels=c.labels,
+                operator=c.operator,
+            )
+            for c in query_structure.clauses
+        ],
+        intent=query_structure.intent,
+        summary=query_structure.summary,
+    )
 
 
 def _build_variable_result(row: dict) -> VariableResult:
@@ -420,45 +438,13 @@ async def search(
             )
         t_pipeline = time.monotonic()
 
-    # Deterministic lookup — branch on intent
+    # Deterministic lookup — branch on intent (shared with /search/agent)
     index = get_index()
     intent = query_model.intent
-    studies: list[dict] = []
-    variable_rows: list[dict] = []
-    total_variable_count = 0
-
-    if query_model.mentions:
-        include, exclude = _split_mentions(query_model.mentions, index)
-        if intent == "ambiguous":
-            pass  # Ambiguous — return clarification message only
-        elif intent == "variable":
-            # Apply study-level constraints (platform, dataType, etc.)
-            non_measurement = [c for c in include if c[0] != Facet.MEASUREMENT]
-            study_ids: set[str] | None = None
-            if non_measurement:
-                matched = index.query_studies(non_measurement, exclude or None)
-                study_ids = {s.get("dbGapId", "") for s in matched}
-            elif exclude:
-                matched = index.query_studies([], exclude)
-                study_ids = {s.get("dbGapId", "") for s in matched}
-
-            # Collect all measurement concepts and query variables
-            # via ISA closure (matched_variables are kept for display
-            # but not used as a SQL filter — the concept tag is enough).
-            all_concepts: list[str] = []
-            for m in query_model.mentions:
-                if m.facet != Facet.MEASUREMENT or m.exclude:
-                    continue
-                all_concepts.extend(m.values)
-
-            if all_concepts or study_ids:
-                rows, total_variable_count = index.store.query_variables(
-                    concepts=all_concepts or None,
-                    study_ids=study_ids,
-                )
-                variable_rows.extend(rows)
-        else:
-            studies = index.query_studies(include, exclude or None)
+    execution = execute_query_model(query_model, index)
+    studies = execution.studies
+    variable_rows = execution.variable_rows
+    total_variable_count = execution.total_variable_count
 
     t_lookup = time.monotonic()
 
@@ -499,21 +485,7 @@ async def search(
         message = None
 
     # Convert internal QueryStructure to API model
-    api_query_structure: ApiQueryStructure | None = None
-    if query_structure is not None:
-        api_query_structure = ApiQueryStructure(
-            clauses=[
-                ApiQueryClause(
-                    exclude=c.exclude,
-                    facet=c.facet,
-                    labels=c.labels,
-                    operator=c.operator,
-                )
-                for c in query_structure.clauses
-            ],
-            intent=query_structure.intent,
-            summary=query_structure.summary,
-        )
+    api_query_structure = _to_api_query_structure(query_structure)
 
     response = SearchResponse(
         intent=intent,

--- a/backend/concept_search/response_summary.py
+++ b/backend/concept_search/response_summary.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from .index import ConceptIndex
 from .mention_constraints import split_mentions
-from .models import Facet, QueryModel, ResolvedMention
+from .models import Facet, Intent, QueryModel, ResolvedMention
 
 # Display names for platform short codes.
 _PLATFORM_DISPLAY: dict[str, str] = {
@@ -60,7 +60,7 @@ class QueryStructure:
     def __init__(
         self,
         clauses: list[QueryClause],
-        intent: str,
+        intent: Intent,
         summary: str = "",
     ) -> None:
         self.clauses = clauses

--- a/backend/concept_search/search_execution.py
+++ b/backend/concept_search/search_execution.py
@@ -1,0 +1,84 @@
+"""Deterministic execution of a resolved ``QueryModel`` against the catalog.
+
+Shared by the live ``/search`` endpoint and the agentic ``/search/agent``
+endpoint so the lookup behaviour is identical: both build a ``QueryModel`` (via
+different means) and run it through the same DuckDB lookup here. This module
+does **not** decide the user-facing message — callers own that (deterministic
+summary for ``/search``; the agent's prose for ``/search/agent``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .index import ConceptIndex
+from .mention_constraints import split_mentions
+from .models import Facet, QueryModel
+
+
+@dataclass
+class ExecutionResult:
+    """Raw lookup output for a ``QueryModel`` (rows, not API models)."""
+
+    studies: list[dict] = field(default_factory=list)
+    total_variable_count: int = 0
+    variable_rows: list[dict] = field(default_factory=list)
+
+
+def execute_query_model(query_model: QueryModel, index: ConceptIndex) -> ExecutionResult:
+    """Run a resolved query against the catalog and return matching rows.
+
+    Branches on ``query_model.intent``:
+
+    - ``ambiguous`` — no lookup (caller returns a clarification message only).
+    - ``variable`` — apply study-level constraints, then query variables for the
+      measurement concepts via ISA closure.
+    - ``study`` (default) — faceted study search.
+
+    Args:
+        query_model: The resolved query with mentions and intent.
+        index: ConceptIndex providing the study/variable store.
+
+    Returns:
+        An ExecutionResult with the matched study/variable rows and the
+        pre-limit variable count.
+    """
+    result = ExecutionResult()
+    if not query_model.mentions:
+        return result
+
+    include, exclude = split_mentions(query_model.mentions, index)
+    intent = query_model.intent
+
+    if intent == "ambiguous":
+        return result
+
+    if intent == "variable":
+        # Apply study-level constraints (platform, dataType, etc.) first.
+        non_measurement = [c for c in include if c[0] != Facet.MEASUREMENT]
+        study_ids: set[str] | None = None
+        if non_measurement:
+            matched = index.query_studies(non_measurement, exclude or None)
+            study_ids = {s.get("dbGapId", "") for s in matched}
+        elif exclude:
+            matched = index.query_studies([], exclude)
+            study_ids = {s.get("dbGapId", "") for s in matched}
+
+        # Collect measurement concepts and query variables via ISA closure
+        # (matched_variables are kept for display but not used as a SQL filter).
+        all_concepts: list[str] = []
+        for m in query_model.mentions:
+            if m.facet != Facet.MEASUREMENT or m.exclude:
+                continue
+            all_concepts.extend(m.values)
+
+        if all_concepts or study_ids:
+            rows, result.total_variable_count = index.store.query_variables(
+                concepts=all_concepts or None,
+                study_ids=study_ids,
+            )
+            result.variable_rows.extend(rows)
+        return result
+
+    result.studies = index.query_studies(include, exclude or None)
+    return result

--- a/backend/concept_search/search_execution.py
+++ b/backend/concept_search/search_execution.py
@@ -1,11 +1,12 @@
 """Deterministic execution of a resolved ``QueryModel`` against the catalog.
 
 The shared lookup seam: ``/search`` calls it today, and the upcoming
-``/search/agent`` endpoint will run the same store lookup so both execute a
-``QueryModel`` identically (each builds the model by different means). The
-lookup goes through ``ConceptIndex`` / the swappable ``StudyStore`` backend
-(DuckDB today). This
-module does **not** decide the user-facing message — callers own that
+``/search/agent`` endpoint will run the same lookup, so both execute a
+``QueryModel`` identically (each builds the model by different means). The lookup
+goes through ``ConceptIndex`` and its swappable ``StudyStore`` backend (DuckDB
+today).
+
+This module does **not** decide the user-facing message — callers own that
 (deterministic summary for ``/search``; the agent's prose for ``/search/agent``).
 """
 

--- a/backend/concept_search/search_execution.py
+++ b/backend/concept_search/search_execution.py
@@ -1,10 +1,10 @@
 """Deterministic execution of a resolved ``QueryModel`` against the catalog.
 
-Shared by the live ``/search`` endpoint and the agentic ``/search/agent``
-endpoint so the lookup behaviour is identical: both build a ``QueryModel`` (via
-different means) and run it through the same DuckDB lookup here. This module
-does **not** decide the user-facing message — callers own that (deterministic
-summary for ``/search``; the agent's prose for ``/search/agent``).
+The shared lookup seam: ``/search`` calls it today, and the upcoming
+``/search/agent`` endpoint will run the same DuckDB lookup so both execute a
+``QueryModel`` identically (each builds the model by different means). This
+module does **not** decide the user-facing message — callers own that
+(deterministic summary for ``/search``; the agent's prose for ``/search/agent``).
 """
 
 from __future__ import annotations
@@ -43,17 +43,13 @@ def execute_query_model(query_model: QueryModel, index: ConceptIndex) -> Executi
         An ExecutionResult with the matched study/variable rows and the
         pre-limit variable count.
     """
-    result = ExecutionResult()
-    if not query_model.mentions:
-        return result
+    # Ambiguous intent (or no mentions) — no lookup; the caller returns a message.
+    if not query_model.mentions or query_model.intent == "ambiguous":
+        return ExecutionResult()
 
     include, exclude = split_mentions(query_model.mentions, index)
-    intent = query_model.intent
 
-    if intent == "ambiguous":
-        return result
-
-    if intent == "variable":
+    if query_model.intent == "variable":
         # Apply study-level constraints (platform, dataType, etc.) first.
         non_measurement = [c for c in include if c[0] != Facet.MEASUREMENT]
         study_ids: set[str] | None = None
@@ -72,13 +68,12 @@ def execute_query_model(query_model: QueryModel, index: ConceptIndex) -> Executi
                 continue
             all_concepts.extend(m.values)
 
-        if all_concepts or study_ids:
-            rows, result.total_variable_count = index.store.query_variables(
-                concepts=all_concepts or None,
-                study_ids=study_ids,
-            )
-            result.variable_rows.extend(rows)
-        return result
+        if not (all_concepts or study_ids):
+            return ExecutionResult()
+        rows, total = index.store.query_variables(
+            concepts=all_concepts or None,
+            study_ids=study_ids,
+        )
+        return ExecutionResult(variable_rows=rows, total_variable_count=total)
 
-    result.studies = index.query_studies(include, exclude or None)
-    return result
+    return ExecutionResult(studies=index.query_studies(include, exclude or None))

--- a/backend/concept_search/search_execution.py
+++ b/backend/concept_search/search_execution.py
@@ -1,8 +1,10 @@
 """Deterministic execution of a resolved ``QueryModel`` against the catalog.
 
 The shared lookup seam: ``/search`` calls it today, and the upcoming
-``/search/agent`` endpoint will run the same DuckDB lookup so both execute a
-``QueryModel`` identically (each builds the model by different means). This
+``/search/agent`` endpoint will run the same store lookup so both execute a
+``QueryModel`` identically (each builds the model by different means). The
+lookup goes through ``ConceptIndex`` / the swappable ``StudyStore`` backend
+(DuckDB today). This
 module does **not** decide the user-facing message — callers own that
 (deterministic summary for ``/search``; the agent's prose for ``/search/agent``).
 """


### PR DESCRIPTION
Closes #366. First slice of the agent-loop productionization epic #365.

## What

Behavior-preserving refactor of the `/search` handler:
- **New `backend/concept_search/search_execution.py`** — `execute_query_model(query_model, index) -> ExecutionResult`, the intent-branching study/variable lookup lifted **verbatim** out of `/search` (ambiguous → no lookup; variable → study-constrain + `query_variables` via ISA closure; study → `query_studies`).
- **`api.py`** — `/search` now calls `execute_query_model()`; extracted `_to_api_query_structure()` to remove the duplicated QueryStructure→API conversion. Now-unused imports (`Facet`, `split_mentions`) dropped.

## Why

The upcoming `/search/agent` endpoint must run the **same** deterministic lookup on a `QueryModel`. This extracts the shared seam so both endpoints execute identically — and it's a standalone cleanup. No new endpoints, behavior, or dependencies.

## Verification

- `/search` output unchanged — the lookup logic is moved verbatim. Smoke-tested study / variable / empty-result(diagnose) intents end-to-end.
- `pytest -m "not evals"` → **354 passed** (unchanged count). `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
