### PR TITLE
ci: add backend lint + unit-test checks

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -1,0 +1,35 @@
+name: Backend checks
+
+# Lint + unit tests for the concept-search backend. Evals are intentionally
+# excluded (-m "not evals"): they call the Anthropic API (cost, non-determinism,
+# would need a secret), so they run manually, not as a PR gate.
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-checks.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-checks.yml"
+
+concurrency:
+  group: backend-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - run: uv run ruff check concept_search/ tests/
+      - run: uv run ruff format --check concept_search/ tests/
+      - run: uv run python -m pytest tests/ -q -m "not evals"

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -18,6 +18,10 @@ concurrency:
   group: backend-checks-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: this job only reads the repo (checkout + local tooling).
+permissions:
+  contents: read
+
 jobs:
   backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
-      - run: uv sync
+      - run: uv sync --frozen # fail if uv.lock is out of date (matches Dockerfile)
       - run: uv run ruff check concept_search/ tests/
       - run: uv run ruff format --check concept_search/ tests/
       - run: uv run python -m pytest tests/ -q -m "not evals"

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -29,6 +29,9 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
+      # setup-uv exports VIRTUAL_ENV pointing at the workspace-root .venv, but the
+      # project lives in backend/; clear it so uv uses backend/.venv without warning.
+      - run: echo "VIRTUAL_ENV=" >> "$GITHUB_ENV"
       - run: uv sync --frozen # fail if uv.lock is out of date (matches Dockerfile)
       - run: uv run ruff check concept_search/ tests/
       - run: uv run ruff format --check concept_search/ tests/


### PR DESCRIPTION
Closes #369. Part of the agent-loop productionization epic #365.

## What

Adds `.github/workflows/backend-checks.yml` — a backend PR gate mirroring the frontend `run-checks.yml`. Backend currently has **no** automated check; this gives the agent-loop PRs (B, C, …) a real green check.

Steps (in `backend/`): `uv sync` → `ruff check` → `ruff format --check` → `pytest -m "not evals"`.

## Decisions

- **Tests only, not evals.** `-m "not evals"` excludes the LLM-calling suites — they cost money, are non-deterministic, and would need `ANTHROPIC_API_KEY` in CI. Evals stay manual; a scheduled/manual eval workflow can be a later item.
- **No secrets / offline.** Verified the gate needs none: `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 ANTHROPIC_API_KEY= pytest -m "not evals"` → **354 passed, 1 skipped, ~5s** (no HF model download, no data files).
- **Path-scoped** to `backend/**` so it doesn't run `uv sync` on frontend-only PRs. The trigger also includes this workflow file, so **this PR self-tests** — you should see the `backend` check run green right here.
- **Python 3.13** to match `backend/Dockerfile`.

## Out of scope

- Evals in CI (future manual/scheduled workflow).
- Modernizing the frontend `run-checks.yml` action versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
