### PR TITLE
fix: drop blank dbGapId from study_ids set in variable lookup

### DIFF
--- a/backend/concept_search/search_execution.py
+++ b/backend/concept_search/search_execution.py
@@ -58,10 +58,10 @@ def execute_query_model(query_model: QueryModel, index: ConceptIndex) -> Executi
         study_ids: set[str] | None = None
         if non_measurement:
             matched = index.query_studies(non_measurement, exclude or None)
-            study_ids = {s.get("dbGapId", "") for s in matched}
+            study_ids = {sid for s in matched if (sid := s.get("dbGapId"))}
         elif exclude:
             matched = index.query_studies([], exclude)
-            study_ids = {s.get("dbGapId", "") for s in matched}
+            study_ids = {sid for s in matched if (sid := s.get("dbGapId"))}
 
         # Collect measurement concepts and query variables via ISA closure
         # (matched_variables are kept for display but not used as a SQL filter).

--- a/backend/concept_search/search_execution.py
+++ b/backend/concept_search/search_execution.py
@@ -58,10 +58,10 @@ def execute_query_model(query_model: QueryModel, index: ConceptIndex) -> Executi
         study_ids: set[str] | None = None
         if non_measurement:
             matched = index.query_studies(non_measurement, exclude or None)
-            study_ids = {sid for s in matched if (sid := s.get("dbGapId"))}
+            study_ids = {s["dbGapId"] for s in matched if s.get("dbGapId")}
         elif exclude:
             matched = index.query_studies([], exclude)
-            study_ids = {sid for s in matched if (sid := s.get("dbGapId"))}
+            study_ids = {s["dbGapId"] for s in matched if s.get("dbGapId")}
 
         # Collect measurement concepts and query variables via ISA closure
         # (matched_variables are kept for display but not used as a SQL filter).

--- a/backend/concept_search/search_execution.py
+++ b/backend/concept_search/search_execution.py
@@ -56,11 +56,8 @@ def execute_query_model(query_model: QueryModel, index: ConceptIndex) -> Executi
         # Apply study-level constraints (platform, dataType, etc.) first.
         non_measurement = [c for c in include if c[0] != Facet.MEASUREMENT]
         study_ids: set[str] | None = None
-        if non_measurement:
+        if non_measurement or exclude:
             matched = index.query_studies(non_measurement, exclude or None)
-            study_ids = {s["dbGapId"] for s in matched if s.get("dbGapId")}
-        elif exclude:
-            matched = index.query_studies([], exclude)
             study_ids = {s["dbGapId"] for s in matched if s.get("dbGapId")}
 
         # Collect measurement concepts and query variables via ISA closure

--- a/backend/tests/test_search_execution.py
+++ b/backend/tests/test_search_execution.py
@@ -1,0 +1,58 @@
+"""Unit tests for execute_query_model — the shared deterministic lookup."""
+
+from __future__ import annotations
+
+from concept_search.models import Facet, QueryModel, ResolvedMention
+from concept_search.search_execution import execute_query_model
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def query_variables(self, concepts=None, limit=500, study_ids=None, variable_names=None):
+        self.calls.append({"concepts": concepts, "study_ids": study_ids})
+        return ([{"variableName": "v1"}], 1)
+
+
+class _FakeIndex:
+    """Minimal ConceptIndex stand-in returning fixed studies."""
+
+    def __init__(self, studies: list[dict]) -> None:
+        self._studies = studies
+        self.store = _FakeStore()
+
+    def query_studies(self, include, exclude=None):
+        return self._studies
+
+
+def test_blank_study_ids_do_not_trigger_variable_query() -> None:
+    """A matched study without dbGapId must not become a '' study-id constraint.
+
+    Regression for #368: previously the blank "" made the empty-constraint gate
+    truthy and passed `study_id IN ('')` to query_variables.
+    """
+    index = _FakeIndex(studies=[{"title": "study with no dbGapId"}])
+    query = QueryModel(
+        intent="variable",
+        mentions=[ResolvedMention(facet=Facet.PLATFORM, original_text="BDC", values=["BDC"])],
+    )
+
+    result = execute_query_model(query, index)
+
+    assert result.variable_rows == []
+    assert result.total_variable_count == 0
+    assert index.store.calls == []  # gate stays empty — query_variables not called
+
+
+def test_valid_study_ids_pass_through() -> None:
+    """Studies with real dbGapIds still flow through as a study-id constraint."""
+    index = _FakeIndex(studies=[{"dbGapId": "phs1"}, {"dbGapId": "phs2"}])
+    query = QueryModel(
+        intent="variable",
+        mentions=[ResolvedMention(facet=Facet.PLATFORM, original_text="BDC", values=["BDC"])],
+    )
+
+    execute_query_model(query, index)
+
+    assert index.store.calls[-1]["study_ids"] == {"phs1", "phs2"}


### PR DESCRIPTION
Closes #368.

## Bug

In the variable-intent path of `execute_query_model`, the study-id set used `s.get("dbGapId", "")`. A matched study lacking `dbGapId` contributed `""`, which:
1. **Fooled the empty-constraint gate** — `{""}` is a non-empty (truthy) set, so `not (all_concepts or study_ids)` was `False` and the code proceeded instead of returning empty.
2. **Sent junk to SQL** — `query_variables(study_ids={""})` builds `study_id IN ('')`, which can match variables with empty/null `study_id`.

Latent (every catalog study has a `dbGapId`), and pre-existing — moved verbatim by the #366 refactor, which left it untouched to stay behavior-preserving.

## Fix

```python
study_ids = {sid for s in matched if (sid := s.get("dbGapId"))}
```

Builds the set from real ids only (both occurrences). Now blank ids are dropped, the gate correctly treats "no real study ids" as empty, and no `''` reaches SQL.

## Tests

New `tests/test_search_execution.py`:
- a study without `dbGapId` → `query_variables` is **not** called (gate stays empty);
- valid `dbGapId`s still pass through as a study-id constraint.

356 passed (+2), ruff clean. First fix gated by the new backend CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
