### PR TITLE
feat: /search/agent endpoint (wire orchestrator + session store)

### DIFF
--- a/backend/concept_search/api.py
+++ b/backend/concept_search/api.py
@@ -536,7 +536,9 @@ async def search(
     return response
 
 
-_MAX_AGENT_HISTORY = 40  # messages of pydantic-ai history sent to the model
+# truncate_history keeps the first message plus the most recent N, so up to N+1
+# pydantic-ai messages are sent to the model (and retained in the stored history).
+_MAX_AGENT_HISTORY = 40
 _MAX_SESSION_MESSAGES = 50  # user/assistant text turns retained in the persisted transcript
 
 
@@ -611,15 +613,17 @@ async def search_agent(
         variables=[_build_variable_result(r) for r in execution.variable_rows],
     )
 
-    # Persist conversation state for the next turn.
+    # Persist conversation state for the next turn. Both histories are bounded
+    # on write so stored state can't grow without limit (matters once the store
+    # is DynamoDB, with per-item size caps). Stopgap — a coherent truncation
+    # policy for both is tracked in #380.
     state.query = query_model
     state.pending = deps.pending
-    state.agent_message_history = serialize_history(new_history)
+    state.agent_message_history = serialize_history(
+        truncate_history(new_history, _MAX_AGENT_HISTORY)
+    )
     state.messages.append(ConversationMessage(content=request.query, role="user"))
     state.messages.append(ConversationMessage(content=reply, role="assistant"))
-    # Stopgap bound so the persisted transcript can't grow without limit (matters
-    # once the store is DynamoDB, with per-item size caps). A coherent on-write
-    # truncation policy for both histories is tracked in #380.
     state.messages = state.messages[-_MAX_SESSION_MESSAGES:]
     await store.save(request.session_id, state)
 

--- a/backend/concept_search/api.py
+++ b/backend/concept_search/api.py
@@ -537,6 +537,7 @@ async def search(
 
 
 _MAX_AGENT_HISTORY = 40  # messages of pydantic-ai history sent to the model
+_MAX_SESSION_MESSAGES = 50  # user/assistant text turns retained in the persisted transcript
 
 
 @app.post("/search/agent", response_model=SearchResponse)
@@ -616,6 +617,10 @@ async def search_agent(
     state.agent_message_history = serialize_history(new_history)
     state.messages.append(ConversationMessage(content=request.query, role="user"))
     state.messages.append(ConversationMessage(content=reply, role="assistant"))
+    # Stopgap bound so the persisted transcript can't grow without limit (matters
+    # once the store is DynamoDB, with per-item size caps). A coherent on-write
+    # truncation policy for both histories is tracked in #380.
+    state.messages = state.messages[-_MAX_SESSION_MESSAGES:]
     await store.save(request.session_id, state)
 
     _log_json(

--- a/backend/concept_search/api.py
+++ b/backend/concept_search/api.py
@@ -20,6 +20,7 @@ from fastapi.responses import JSONResponse
 from .api_models import (
     DemographicCategory,
     DemographicDistribution,
+    SearchAgentRequest,
     SearchRequest,
     SearchResponse,
     SearchTiming,
@@ -29,8 +30,15 @@ from .api_models import (
 )
 from .api_models import QueryClause as ApiQueryClause
 from .api_models import QueryStructure as ApiQueryStructure
+from .conversation_agent import (
+    AgentDeps,
+    deserialize_history,
+    run_conversation,
+    serialize_history,
+)
 from .index import get_index
 from .models import (
+    ConversationMessage,
     QueryModel,
     ResolvedMention,
     RouteRemove,
@@ -49,6 +57,7 @@ from .response_summary import (
 )
 from .router_agent import run_router
 from .search_execution import execute_query_model
+from .session_store import SessionState, get_session_store, truncate_history
 
 # Structured JSON logging to stdout (picked up by CloudWatch via App Runner)
 logging.basicConfig(
@@ -363,6 +372,26 @@ async def _handle_route(query: str, previous_query: QueryModel) -> QueryModel:
     return result
 
 
+def _timeout_response(elapsed_ms: int, message: str) -> SearchResponse:
+    """Build an empty SearchResponse for a timeout/error on either search path."""
+    return SearchResponse(
+        message=message,
+        query=QueryModel(mentions=[]),
+        studies=[],
+        timing=SearchTiming(lookup_ms=0, pipeline_ms=elapsed_ms, total_ms=elapsed_ms),
+        total_studies=0,
+    )
+
+
+def _rate_limit_response(client_ip: str, query: str) -> JSONResponse:
+    """Log a rate-limit hit and build the 429 response (shared by both search paths)."""
+    _log_json(event="rate_limited", ip=client_ip, query=query)
+    return JSONResponse(
+        content={"detail": "Too many requests — please try again later."},
+        status_code=429,
+    )
+
+
 @app.post("/search", response_model=SearchResponse)
 async def search(
     request: SearchRequest, fastapi_request: Request
@@ -371,11 +400,7 @@ async def search(
     # 1. Rate limit check
     client_ip = _get_client_ip(fastapi_request)
     if not await _rate_limiter.is_allowed(client_ip):
-        _log_json(event="rate_limited", ip=client_ip, query=request.query)
-        return JSONResponse(
-            content={"detail": "Too many requests — please try again later."},
-            status_code=429,
-        )
+        return _rate_limit_response(client_ip, request.query)
 
     has_query = bool(request.query and request.query.strip())
     has_previous = request.previous_query is not None
@@ -411,17 +436,7 @@ async def search(
         except (TimeoutError, asyncio.CancelledError):
             _log_json(event="search_timeout", query=request.query)
             elapsed_ms = int((time.monotonic() - t_start) * 1000)
-            return SearchResponse(
-                message="Search timed out — please try a simpler query.",
-                query=QueryModel(mentions=[]),
-                studies=[],
-                timing=SearchTiming(
-                    lookup_ms=0,
-                    pipeline_ms=elapsed_ms,
-                    total_ms=elapsed_ms,
-                ),
-                total_studies=0,
-            )
+            return _timeout_response(elapsed_ms, "Search timed out — please try a simpler query.")
         except Exception as exc:
             _log_json(
                 event="search_pipeline_error",
@@ -430,17 +445,7 @@ async def search(
                 error_type=type(exc).__name__,
             )
             elapsed_ms = int((time.monotonic() - t_start) * 1000)
-            return SearchResponse(
-                message="Something went wrong — please try again.",
-                query=QueryModel(mentions=[]),
-                studies=[],
-                timing=SearchTiming(
-                    lookup_ms=0,
-                    pipeline_ms=elapsed_ms,
-                    total_ms=elapsed_ms,
-                ),
-                total_studies=0,
-            )
+            return _timeout_response(elapsed_ms, "Something went wrong — please try again.")
         t_pipeline = time.monotonic()
 
     # Deterministic lookup — branch on intent (shared with /search/agent)
@@ -528,6 +533,101 @@ async def search(
         lookup_ms=lookup_ms,
     )
 
+    return response
+
+
+_MAX_AGENT_HISTORY = 40  # messages of pydantic-ai history sent to the model
+
+
+@app.post("/search/agent", response_model=SearchResponse)
+async def search_agent(
+    request: SearchAgentRequest, fastapi_request: Request
+) -> SearchResponse | JSONResponse:
+    """Agentic multi-turn search (epic #365).
+
+    The orchestrator builds a QueryModel via tools; the backend owns conversation
+    state keyed by ``session_id``. Returns the same SearchResponse shape as
+    ``/search`` — rows from deterministic execution, ``message`` is the agent's reply.
+    """
+    client_ip = _get_client_ip(fastapi_request)
+    if not await _rate_limiter.is_allowed(client_ip):
+        return _rate_limit_response(client_ip, request.query)
+
+    _log_json(event="agent_request", session_id=request.session_id, query=request.query)
+    t_start = time.monotonic()
+
+    store = get_session_store()
+    state = await store.get(request.session_id) or SessionState()
+    index = get_index()
+    deps = AgentDeps(
+        index=index, query_state=state.query or QueryModel(), pending=list(state.pending)
+    )
+    history = truncate_history(
+        deserialize_history(state.agent_message_history), _MAX_AGENT_HISTORY
+    )
+
+    try:
+        async with _pipeline_semaphore:
+            reply, query_model, new_history = await asyncio.wait_for(
+                run_conversation(request.query, deps, message_history=history),
+                timeout=60.0,
+            )
+    except (TimeoutError, asyncio.CancelledError):
+        _log_json(event="agent_timeout", session_id=request.session_id, query=request.query)
+        elapsed_ms = int((time.monotonic() - t_start) * 1000)
+        return _timeout_response(elapsed_ms, "Search timed out — please try again.")
+    except Exception as exc:  # noqa: BLE001 — surface a friendly reply, log the detail
+        _log_json(
+            event="agent_error",
+            session_id=request.session_id,
+            query=request.query,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        elapsed_ms = int((time.monotonic() - t_start) * 1000)
+        return _timeout_response(elapsed_ms, "Something went wrong — please try again.")
+
+    t_pipeline = time.monotonic()
+    execution = execute_query_model(query_model, index)
+    t_lookup = time.monotonic()
+    pipeline_ms = int((t_pipeline - t_start) * 1000)
+    lookup_ms = int((t_lookup - t_pipeline) * 1000)
+
+    query_structure = build_query_structure(query_model, index)
+    response = SearchResponse(
+        intent=query_model.intent,
+        message=reply,
+        query=query_model,
+        query_structure=_to_api_query_structure(query_structure),
+        studies=[_build_study_summary(s) for s in execution.studies],
+        timing=SearchTiming(
+            lookup_ms=lookup_ms,
+            pipeline_ms=pipeline_ms,
+            total_ms=pipeline_ms + lookup_ms,
+        ),
+        total_studies=len(execution.studies),
+        total_variables=execution.total_variable_count,
+        variables=[_build_variable_result(r) for r in execution.variable_rows],
+    )
+
+    # Persist conversation state for the next turn.
+    state.query = query_model
+    state.pending = deps.pending
+    state.agent_message_history = serialize_history(new_history)
+    state.messages.append(ConversationMessage(content=request.query, role="user"))
+    state.messages.append(ConversationMessage(content=reply, role="assistant"))
+    await store.save(request.session_id, state)
+
+    _log_json(
+        event="agent_response",
+        session_id=request.session_id,
+        query=request.query,
+        intent=query_model.intent,
+        total_studies=len(execution.studies),
+        total_variables=execution.total_variable_count,
+        pipeline_ms=pipeline_ms,
+        lookup_ms=lookup_ms,
+    )
     return response
 
 

--- a/backend/concept_search/api_models.py
+++ b/backend/concept_search/api_models.py
@@ -61,6 +61,19 @@ class SearchRequest(BaseModel):
         return self
 
 
+class SearchAgentRequest(BaseModel):
+    """Incoming message for the agentic ``/search/agent`` endpoint.
+
+    The backend owns conversation state keyed by ``session_id`` (via the
+    SessionStore), so the client only sends a session id and the new message.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    query: str = Field(default="", max_length=1000)
+    session_id: str = Field(min_length=1, max_length=128)
+
+
 class DemographicCategory(BaseModel):
     """A single category within a demographic distribution."""
 

--- a/backend/concept_search/api_models.py
+++ b/backend/concept_search/api_models.py
@@ -73,6 +73,17 @@ class SearchAgentRequest(BaseModel):
     query: str = Field(default="", max_length=1000)
     session_id: str = Field(min_length=1, max_length=128)
 
+    @model_validator(mode="after")
+    def require_non_empty_query(self) -> SearchAgentRequest:
+        """Require a non-empty user message.
+
+        The agent path carries no ``previousQuery`` — conversation state lives
+        server-side — so every turn must supply a new message to act on.
+        """
+        if not self.query.strip():
+            raise ValueError("'query' must be a non-empty message.")
+        return self
+
 
 class DemographicCategory(BaseModel):
     """A single category within a demographic distribution."""

--- a/backend/concept_search/api_models.py
+++ b/backend/concept_search/api_models.py
@@ -70,15 +70,17 @@ class SearchAgentRequest(BaseModel):
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    query: str = Field(default="", max_length=1000)
+    query: str = Field(max_length=1000)
     session_id: str = Field(min_length=1, max_length=128)
 
     @model_validator(mode="after")
     def require_non_empty_query(self) -> SearchAgentRequest:
-        """Require a non-empty user message.
+        """Reject a whitespace-only ``query``.
 
-        The agent path carries no ``previousQuery`` — conversation state lives
-        server-side — so every turn must supply a new message to act on.
+        ``query`` is required (a missing field is rejected by the schema); this
+        additionally guards against a blank message. The agent path carries no
+        ``previousQuery`` — conversation state lives server-side — so every turn
+        must supply a real message to act on.
         """
         if not self.query.strip():
             raise ValueError("'query' must be a non-empty message.")

--- a/backend/tests/test_api_agent.py
+++ b/backend/tests/test_api_agent.py
@@ -190,3 +190,17 @@ class TestSearchAgentEndpoint:
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.post("/search/agent", json={"query": "diabetes", "sessionId": ""})
         assert resp.status_code == 422
+
+    @patch("concept_search.api.get_index")
+    def test_missing_query_is_rejected(self, mock_index) -> None:
+        """A request without a query fails validation — the agent needs a message."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/search/agent", json={"sessionId": "s1"})
+        assert resp.status_code == 422
+
+    @patch("concept_search.api.get_index")
+    def test_blank_query_is_rejected(self, mock_index) -> None:
+        """A whitespace-only query fails validation."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/search/agent", json={"query": "   ", "sessionId": "s1"})
+        assert resp.status_code == 422

--- a/backend/tests/test_api_agent.py
+++ b/backend/tests/test_api_agent.py
@@ -1,0 +1,192 @@
+"""Endpoint tests for the agentic ``/search/agent`` route (no LLM calls).
+
+The orchestrator (``run_conversation``) and the index are mocked, so these
+tests exercise only the HTTP wiring: request validation, rate limiting, the
+session-state load/persist round trip, response shaping, and graceful
+timeout/error handling. The agent's own behaviour is covered by the eval
+harnesses (``eval_agent_conversation`` / ``eval_agent_decision``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from concept_search import api as api_module
+from concept_search.api import app
+from concept_search.models import Facet, QueryModel, ResolvedMention
+from concept_search.session_store import InMemorySessionStore
+
+
+def _study(title: str = "Study A", db_gap_id: str = "phs000001") -> dict:
+    """Build a minimal study dict shaped like a store row."""
+    return {
+        "consentCodes": [],
+        "dataTypes": [],
+        "dbGapId": db_gap_id,
+        "focus": "Diabetes Mellitus",
+        "participantCount": 100,
+        "platforms": ["AnVIL"],
+        "studyDesigns": [],
+        "title": title,
+    }
+
+
+def _query(text: str = "diabetes") -> QueryModel:
+    """A committed study-intent query with one resolved focus mention."""
+    return QueryModel(
+        intent="study",
+        mentions=[
+            ResolvedMention(
+                facet=Facet.FOCUS,
+                original_text=text,
+                values=["Diabetes Mellitus"],
+            )
+        ],
+    )
+
+
+def _recording_run(seen: list[list[str]]):
+    """Build a run_conversation stub that records each turn's incoming query_state.
+
+    Appends the ``original_text`` of every mention the orchestrator was handed
+    (i.e. the persisted state loaded for this turn) to ``seen``, so tests can
+    assert what prior state carried over.
+    """
+
+    def fake_run(message, deps, message_history=None, model=None):
+        seen.append([m.original_text for m in deps.query_state.mentions])
+        return (f"reply: {message}", _query(), [])
+
+    return fake_run
+
+
+@pytest.fixture
+def agent_client():
+    """A TestClient backed by a fresh in-memory session store per test."""
+    store = InMemorySessionStore()
+    with patch("concept_search.api.get_session_store", return_value=store):
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+class TestSearchAgentEndpoint:
+    """HTTP-level tests for POST /search/agent."""
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_happy_path_returns_search_response(self, mock_index, mock_run, agent_client) -> None:
+        """A successful turn returns 200 with the agent reply and matched studies."""
+        mock_index.return_value.query_studies.return_value = [_study()]
+        mock_index.return_value.stats = {}
+        mock_run.return_value = ("Here are diabetes studies.", _query(), [])
+
+        resp = agent_client.post(
+            "/search/agent",
+            json={"query": "diabetes studies", "sessionId": "s1"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["message"] == "Here are diabetes studies."
+        assert data["totalStudies"] == 1
+        assert data["studies"][0]["title"] == "Study A"
+        assert data["intent"] == "study"
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_session_continuity_loads_prior_state(
+        self, mock_index, mock_run, agent_client
+    ) -> None:
+        """Turn 2 reuses turn 1's persisted query state for the same session id."""
+        mock_index.return_value.query_studies.return_value = []
+        mock_index.return_value.stats = {}
+
+        seen: list[list[str]] = []
+        mock_run.side_effect = _recording_run(seen)
+
+        r1 = agent_client.post("/search/agent", json={"query": "diabetes", "sessionId": "s1"})
+        r2 = agent_client.post("/search/agent", json={"query": "only on BDC", "sessionId": "s1"})
+
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        # Turn 1 started from empty state; turn 2 saw turn 1's committed query.
+        assert seen[0] == []
+        assert seen[1] == ["diabetes"]
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_separate_sessions_are_isolated(self, mock_index, mock_run, agent_client) -> None:
+        """A different session id does not inherit another session's state."""
+        mock_index.return_value.query_studies.return_value = []
+        mock_index.return_value.stats = {}
+
+        seen: list[list[str]] = []
+        mock_run.side_effect = _recording_run(seen)
+
+        agent_client.post("/search/agent", json={"query": "diabetes", "sessionId": "s1"})
+        agent_client.post("/search/agent", json={"query": "asthma", "sessionId": "s2"})
+
+        assert seen[0] == []  # s1 first turn
+        assert seen[1] == []  # s2 first turn — not polluted by s1
+
+    @patch("concept_search.api.get_index")
+    def test_rate_limit_returns_429(self, mock_index) -> None:
+        """A rate-limited client gets a 429 before the orchestrator runs."""
+        with (
+            patch.object(
+                api_module._rate_limiter, "is_allowed", new=AsyncMock(return_value=False)
+            ),
+            patch("concept_search.api.run_conversation") as mock_run,
+        ):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/search/agent", json={"query": "x", "sessionId": "s1"})
+
+        assert resp.status_code == 429
+        mock_run.assert_not_called()
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_timeout_returns_graceful_response(self, mock_index, mock_run, agent_client) -> None:
+        """An orchestrator timeout yields an empty 200 with a friendly message."""
+        mock_index.return_value.stats = {}
+        mock_run.side_effect = TimeoutError
+
+        resp = agent_client.post("/search/agent", json={"query": "x", "sessionId": "s1"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["totalStudies"] == 0
+        assert data["studies"] == []
+        assert "timed out" in data["message"].lower()
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_orchestrator_error_returns_graceful_response(
+        self, mock_index, mock_run, agent_client
+    ) -> None:
+        """An unexpected orchestrator error yields an empty 200, not a 500."""
+        mock_index.return_value.stats = {}
+        mock_run.side_effect = RuntimeError("boom")
+
+        resp = agent_client.post("/search/agent", json={"query": "x", "sessionId": "s1"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["totalStudies"] == 0
+        assert "went wrong" in data["message"].lower()
+
+    @patch("concept_search.api.get_index")
+    def test_missing_session_id_is_rejected(self, mock_index) -> None:
+        """A request without a session id fails validation (422)."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/search/agent", json={"query": "diabetes"})
+        assert resp.status_code == 422
+
+    @patch("concept_search.api.get_index")
+    def test_empty_session_id_is_rejected(self, mock_index) -> None:
+        """An empty session id fails validation (min_length=1)."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/search/agent", json={"query": "diabetes", "sessionId": ""})
+        assert resp.status_code == 422


### PR DESCRIPTION
Closes #378. Part of epic #365.

## What

Wires the B1 conversation orchestrator (#375) to an HTTP endpoint. `POST /search/agent` owns multi-turn conversation state keyed by `session_id` (via the existing `SessionStore`) and returns the **same `SearchResponse` shape as `/search`**, so the frontend can swap endpoints with no response-parsing changes.

This is the slice where the B1 pieces finally get used end-to-end: carried-over `pending`, `truncate_history`, `serialize`/`deserialize_history`, and `execute_query_model` (PR A).

## Changes

- **`api_models.py`** — `SearchAgentRequest` (`query` ≤1000, `sessionId` min 1 / max 128, camel aliases). The backend owns state, so the client sends only a session id + the new message.
- **`api.py`**
  - `_MAX_AGENT_HISTORY = 40`
  - Shared `_timeout_response` + `_rate_limit_response` helpers — now used by **both** `/search` and `/search/agent` (deduped the inline 429 + timeout/error blocks).
  - `POST /search/agent`: rate-limit → load `SessionState` → build `AgentDeps` + `truncate_history(deserialize_history(...))` → `run_conversation` under the pipeline semaphore + 60s timeout → `execute_query_model` → `SearchResponse(message=reply, …)` → persist query/pending/history/turns.
- **`tests/test_api_agent.py`** (new) — CI-safe endpoint tests (`TestClient`, mocked `get_index` + `run_conversation`, **no LLM**): happy path, session continuity, session isolation, rate-limit 429, timeout, orchestrator error, and request validation (missing/empty `sessionId`).

## Why it's safe to land on `main`

**Additive + dormant.** A new route that doesn't touch `/search`; it stays unused until PR C's non-prod frontend toggle points at it. Rate-limited like `/search`. Gated by backend CI (#370).

## Verification

- `ruff check` + `ruff format --check` clean
- `pytest -m "not evals"` → **389 passed, 7 deselected** (8 new endpoint tests; no API key needed)
- The agent eval harnesses (B1) already validate `run_conversation` behaviour; these tests focus on the HTTP wiring.

## Review process

Claude implementation → `/simplify` (3 cleanups applied) → `/code-review` (high effort, 8 angles: **0 correctness bugs**; applied the rate-limit-429 dedup + test factory findings).

## Deferred (noted for later slices)

- Env-config for `_MAX_AGENT_HISTORY` (it's an internal tuning constant, not an ops knob)
- A shared response-assembly seam between `/search` and `/search/agent` (right call for a small PR in a series)
- A session service layer (endpoint ownership is fine at this size)
- Endpoint env-gating, streaming, DynamoDB `SessionStore` adapter (#360 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)