### PR TITLE
feat: agent search mode behind ?agent=1 URL flag

### DIFF
--- a/app/utils/searchApiUrl.test.ts
+++ b/app/utils/searchApiUrl.test.ts
@@ -1,0 +1,44 @@
+import { getSearchApiUrl } from "./searchApiUrl";
+
+describe("getSearchApiUrl", () => {
+  const ORIGINAL_ENV = process.env.NEXT_PUBLIC_SEARCH_API_URL;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.NEXT_PUBLIC_SEARCH_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SEARCH_API_URL = ORIGINAL_ENV;
+    }
+  });
+
+  it("returns the config URL when the env var is unset", () => {
+    delete process.env.NEXT_PUBLIC_SEARCH_API_URL;
+    expect(getSearchApiUrl("https://api.example.com/search")).toBe(
+      "https://api.example.com/search"
+    );
+  });
+
+  it("prefers the env var over the config URL", () => {
+    process.env.NEXT_PUBLIC_SEARCH_API_URL = "https://env.example.com/search";
+    expect(getSearchApiUrl("https://config.example.com/search")).toBe(
+      "https://env.example.com/search"
+    );
+  });
+
+  it("returns an empty string when neither is set", () => {
+    delete process.env.NEXT_PUBLIC_SEARCH_API_URL;
+    expect(getSearchApiUrl()).toBe("");
+  });
+
+  it("appends /agent when agent mode is requested", () => {
+    delete process.env.NEXT_PUBLIC_SEARCH_API_URL;
+    expect(
+      getSearchApiUrl("https://api.example.com/search", { agent: true })
+    ).toBe("https://api.example.com/search/agent");
+  });
+
+  it("returns an empty string for agent mode when no base URL is set", () => {
+    delete process.env.NEXT_PUBLIC_SEARCH_API_URL;
+    expect(getSearchApiUrl(undefined, { agent: true })).toBe("");
+  });
+});

--- a/app/utils/searchApiUrl.ts
+++ b/app/utils/searchApiUrl.ts
@@ -1,8 +1,20 @@
 /**
  * Returns the search API URL, preferring the env var over the site config value.
+ *
+ * The resolved base URL targets the deterministic `/search` endpoint. Pass
+ * `{ agent: true }` to target the agentic `/search/agent` endpoint instead
+ * (used by the `?agent=1` URL flag); the base URL ends in `/search`, so the
+ * agent URL is simply that with `/agent` appended.
  * @param configUrl - The URL from site config (`config.ai?.url`).
+ * @param options - Resolution options.
+ * @param options.agent - When true, return the `/search/agent` URL.
  * @returns Resolved search API URL, or empty string if neither is set.
  */
-export function getSearchApiUrl(configUrl?: string): string {
-  return process.env.NEXT_PUBLIC_SEARCH_API_URL || configUrl || "";
+export function getSearchApiUrl(
+  configUrl?: string,
+  options?: { agent?: boolean }
+): string {
+  const base = process.env.NEXT_PUBLIC_SEARCH_API_URL || configUrl || "";
+  if (!base) return "";
+  return options?.agent ? `${base}/agent` : base;
 }

--- a/app/views/ResearchView/artifact/form.test.tsx
+++ b/app/views/ResearchView/artifact/form.test.tsx
@@ -18,6 +18,14 @@ const mockChatState = {
   state: { messages: [], status: { loading: false } },
 };
 
+const mockRouter = {
+  query: {} as Record<string, string | string[] | undefined>,
+};
+
+jest.mock("next/router", () => ({
+  useRouter: (): any => mockRouter,
+}));
+
 jest.mock("@databiosphere/findable-ui/lib/hooks/useConfig", () => ({
   useConfig: (): any => ({
     config: { ai: { url: "https://test-api/search" } },
@@ -46,7 +54,8 @@ jest.mock(
 );
 
 jest.mock("../../../utils/searchApiUrl", () => ({
-  getSearchApiUrl: (url: string): string => url,
+  getSearchApiUrl: (url: string, options?: { agent?: boolean }): string =>
+    url ? (options?.agent ? `${url}/agent` : url) : "",
 }));
 
 // --- Helpers ---
@@ -80,6 +89,7 @@ describe("MultiTurnQueryProvider onSubmit", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockChatState.state.messages = [];
+    mockRouter.query = {};
     global.fetch = jest.fn().mockResolvedValue({
       json: () =>
         Promise.resolve({
@@ -313,6 +323,7 @@ describe("MultiTurnQueryProvider onSubmit", () => {
 describe("MultiTurnQueryProvider removeFilter", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouter.query = {};
     mockChatState.state.messages = [
       {
         response: {
@@ -374,6 +385,84 @@ describe("MultiTurnQueryProvider removeFilter", () => {
     expect(body.previousQuery.mentions).toEqual([
       expect.objectContaining({ facet: "focus", originalText: "diabetes" }),
     ]);
+  });
+});
+
+describe("MultiTurnQueryProvider onSubmit (agent mode)", () => {
+  // jsdom does not implement crypto.randomUUID; stub it with incrementing ids
+  // so the "reuse" test can prove the session id is generated once, not per turn.
+  let uuidCounter = 0;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChatState.state.messages = [];
+    mockRouter.query = { agent: "1" };
+    uuidCounter = 0;
+    Object.defineProperty(crypto, "randomUUID", {
+      configurable: true,
+      value: () => `uuid-${++uuidCounter}`,
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          intent: "study",
+          message: "Here are diabetes studies.",
+          query: {
+            intent: "study",
+            mentions: [
+              { facet: "focus", originalText: "diabetes", values: ["DM"] },
+            ],
+            message: null,
+          },
+          timing: { lookupMs: 0, pipelineMs: 0, totalMs: 0 },
+        }),
+      ok: true,
+      status: 200,
+    });
+  });
+
+  it("posts to the agent endpoint with sessionId and no previousQuery", async () => {
+    const { result } = renderOnSubmit();
+
+    await act(async () => {
+      await result.current.onSubmit(
+        mockFormEvent(),
+        { query: "diabetes studies" },
+        defaultOptions
+      );
+    });
+
+    const [calledUrl, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(calledUrl).toBe("https://test-api/search/agent");
+    const body = JSON.parse(init.body);
+    expect(body.query).toBe("diabetes studies");
+    expect(body.sessionId).toBe("uuid-1");
+    expect(body).not.toHaveProperty("previousQuery");
+  });
+
+  it("reuses the same sessionId and never sends previousQuery across turns", async () => {
+    const { result } = renderOnSubmit();
+
+    await act(async () => {
+      await result.current.onSubmit(
+        mockFormEvent(),
+        { query: "diabetes studies" },
+        defaultOptions
+      );
+    });
+    await act(async () => {
+      await result.current.onSubmit(
+        mockFormEvent(),
+        { query: "only on BDC" },
+        defaultOptions
+      );
+    });
+
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    const firstBody = JSON.parse(calls[0][1].body);
+    const secondBody = JSON.parse(calls[1][1].body);
+    expect(secondBody.sessionId).toBe(firstBody.sessionId);
+    expect(secondBody).not.toHaveProperty("previousQuery");
   });
 });
 /* eslint-enable @typescript-eslint/no-explicit-any -- re-enable after test mocks */

--- a/app/views/ResearchView/artifact/form.test.tsx
+++ b/app/views/ResearchView/artifact/form.test.tsx
@@ -392,6 +392,18 @@ describe("MultiTurnQueryProvider onSubmit (agent mode)", () => {
   // jsdom does not implement crypto.randomUUID; stub it with incrementing ids
   // so the "reuse" test can prove the session id is generated once, not per turn.
   let uuidCounter = 0;
+  const originalRandomUUID = Object.getOwnPropertyDescriptor(
+    crypto,
+    "randomUUID"
+  );
+
+  afterEach(() => {
+    if (originalRandomUUID) {
+      Object.defineProperty(crypto, "randomUUID", originalRandomUUID);
+    } else {
+      delete (crypto as { randomUUID?: unknown }).randomUUID;
+    }
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/app/views/ResearchView/artifact/form.test.tsx
+++ b/app/views/ResearchView/artifact/form.test.tsx
@@ -464,6 +464,31 @@ describe("MultiTurnQueryProvider onSubmit (agent mode)", () => {
     expect(secondBody.sessionId).toBe(firstBody.sessionId);
     expect(secondBody).not.toHaveProperty("previousQuery");
   });
+
+  it("surfaces an error and does not get stuck when session id generation fails", async () => {
+    Object.defineProperty(crypto, "randomUUID", {
+      configurable: true,
+      value: () => {
+        throw new Error("insecure context");
+      },
+    });
+    const onError = jest.fn();
+    const { result } = renderOnSubmit();
+
+    await act(async () => {
+      await result.current.onSubmit(
+        mockFormEvent(),
+        { query: "diabetes studies" },
+        { ...defaultOptions, onError }
+      );
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalled();
+    expect(mockDispatch.onSetError).toHaveBeenCalled();
+    // Loading was never entered, so the UI cannot be stuck.
+    expect(mockDispatch.onSetStatus).not.toHaveBeenCalledWith(true);
+  });
 });
 /* eslint-enable @typescript-eslint/no-explicit-any -- re-enable after test mocks */
 /* eslint-enable @typescript-eslint/explicit-function-return-type -- re-enable after test helpers */

--- a/app/views/ResearchView/artifact/form.tsx
+++ b/app/views/ResearchView/artifact/form.tsx
@@ -19,6 +19,7 @@ import {
   useRef,
 } from "react";
 import { getSearchApiUrl } from "../../../utils/searchApiUrl";
+import { useAgentMode } from "../hooks/UseAgentMode/hook";
 
 /**
  * Context for multi-turn filter removal.
@@ -115,9 +116,18 @@ export function MultiTurnQueryProvider({
   children,
 }: MultiTurnQueryProviderProps): JSX.Element {
   const { config } = useConfig();
+  // Opt-in agentic search via the `?agent=1` URL flag. When on, submissions go
+  // to the `/search/agent` endpoint with a server-owned session instead of the
+  // deterministic `/search` previousQuery round-trip.
+  const agentMode = useAgentMode();
   const url = getSearchApiUrl(config.ai?.url);
+  const submitUrl = getSearchApiUrl(config.ai?.url, { agent: agentMode });
   const dispatch = useChatDispatch();
   const lastQueryRef = useRef<MessageResponse["query"] | null>(null);
+  // Conversation id for agent mode; created lazily on first agent submission so
+  // the backend can key multi-turn state. The agent handles resets server-side,
+  // so one id per provider lifetime (one research-view visit) is sufficient.
+  const sessionIdRef = useRef<string>("");
   const abortRef = useRef<AbortController | null>(null);
 
   // Sync lastQueryRef from chat state whenever a new assistant message arrives.
@@ -168,7 +178,7 @@ export function MultiTurnQueryProvider({
       if (options.status.loading) return;
 
       const query = payload.query.trim();
-      if (!query || !url) return;
+      if (!query || !submitUrl) return;
 
       const form = e.currentTarget;
 
@@ -178,11 +188,15 @@ export function MultiTurnQueryProvider({
       options.onMutate?.(form, query);
 
       const body: Record<string, unknown> = { query };
-      if (lastQueryRef.current) {
+      if (agentMode) {
+        // Backend owns conversation state keyed by sessionId — no previousQuery.
+        if (!sessionIdRef.current) sessionIdRef.current = crypto.randomUUID();
+        body.sessionId = sessionIdRef.current;
+      } else if (lastQueryRef.current) {
         body.previousQuery = lastQueryRef.current;
       }
 
-      const data = await postSearch(url, body, abortRef, dispatch);
+      const data = await postSearch(submitUrl, body, abortRef, dispatch);
       if (data) {
         lastQueryRef.current = data.query;
         options.onSuccess?.(data);
@@ -191,7 +205,7 @@ export function MultiTurnQueryProvider({
       }
       options.onSettled?.(form);
     },
-    [dispatch, url]
+    [agentMode, dispatch, submitUrl]
   );
 
   const queryContextValue = useMemo(() => ({ onSubmit }), [onSubmit]);

--- a/app/views/ResearchView/artifact/form.tsx
+++ b/app/views/ResearchView/artifact/form.tsx
@@ -182,19 +182,30 @@ export function MultiTurnQueryProvider({
 
       const form = e.currentTarget;
 
-      dispatch.onSetQuery(query);
-      dispatch.onSetStatus(true);
-      form.reset();
-      options.onMutate?.(form, query);
-
+      // Build the request body before mutating UI state. crypto.randomUUID()
+      // throws on a non-secure origin (HTTP outside localhost); doing it here
+      // surfaces a visible error instead of leaving the form stuck loading.
       const body: Record<string, unknown> = { query };
       if (agentMode) {
         // Backend owns conversation state keyed by sessionId — no previousQuery.
-        if (!sessionIdRef.current) sessionIdRef.current = crypto.randomUUID();
+        try {
+          if (!sessionIdRef.current) sessionIdRef.current = crypto.randomUUID();
+        } catch {
+          dispatch.onSetError(
+            "Agent search needs a secure (HTTPS) connection."
+          );
+          options.onError?.(new Error("Failed to start an agent session."));
+          return;
+        }
         body.sessionId = sessionIdRef.current;
       } else if (lastQueryRef.current) {
         body.previousQuery = lastQueryRef.current;
       }
+
+      dispatch.onSetQuery(query);
+      dispatch.onSetStatus(true);
+      form.reset();
+      options.onMutate?.(form, query);
 
       const data = await postSearch(submitUrl, body, abortRef, dispatch);
       if (data) {

--- a/app/views/ResearchView/hooks/UseAgentMode/hook.ts
+++ b/app/views/ResearchView/hooks/UseAgentMode/hook.ts
@@ -14,5 +14,8 @@ const AGENT_MODE_ENABLED = "1";
  */
 export function useAgentMode(): boolean {
   const { query } = useRouter();
-  return query[AGENT_MODE_PARAM] === AGENT_MODE_ENABLED;
+  // A repeated param (`?agent=1&agent=1`) arrives as a string[]; take the first.
+  const raw = query[AGENT_MODE_PARAM];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return value === AGENT_MODE_ENABLED;
 }

--- a/app/views/ResearchView/hooks/UseAgentMode/hook.ts
+++ b/app/views/ResearchView/hooks/UseAgentMode/hook.ts
@@ -1,0 +1,18 @@
+import { useRouter } from "next/router";
+
+/** URL search param that opts a session into agentic search mode. */
+export const AGENT_MODE_PARAM = "agent";
+
+/** Value of {@link AGENT_MODE_PARAM} that enables agent mode. */
+const AGENT_MODE_ENABLED = "1";
+
+/**
+ * Reads the `?agent=1` URL flag that routes search to the `/search/agent`
+ * endpoint. Single source of truth for the flag so every agent-aware component
+ * (submission, filter chips, history) stays in sync. Honored in all envs.
+ * @returns True when agent mode is enabled via the URL.
+ */
+export function useAgentMode(): boolean {
+  const { query } = useRouter();
+  return query[AGENT_MODE_PARAM] === AGENT_MODE_ENABLED;
+}

--- a/docs/DESIGN-agent-search-mode.md
+++ b/docs/DESIGN-agent-search-mode.md
@@ -1,0 +1,91 @@
+# Design Note: Agent Search Mode (`?agent=1`)
+
+> Status: DRAFT — Jun 2026
+> Refs: epic #365 · backend endpoint #379 · this PR #383 · follow-ups #381 (markdown), #382 (filter chips), #380 (history)
+
+---
+
+## 1. Context
+
+The catalog's conversational search runs the deterministic **`/search`** pipeline
+(Extract → Resolve → Structure → Router), with multi-turn context carried by the
+client via a `previousQuery` round-trip. Epic #365 productionizes an alternative:
+a single Sonnet **orchestrator** with composable tools, exposed at
+**`POST /search/agent`** (#379), which owns conversation state server-side keyed
+by a `sessionId`.
+
+This note documents how the frontend opts into that endpoint **without any new
+UI**, so we can dogfood the agent against the real catalog before deciding
+whether to promote it to the default.
+
+## 2. Enabling agent mode
+
+Append **`?agent=1`** to the research-view URL. The flag is read from the URL
+(`next/router` `router.query.agent`) in `MultiTurnQueryProvider`
+(`app/views/ResearchView/artifact/form.tsx`).
+
+- **No toggle UI.** The flag is the entire opt-in — the prompt window, results
+  table, and filter chips are unchanged.
+- **Honored in all environments.** The agent endpoint is rate-limited
+  server-side; there is no environment gate on the flag. (It calls Sonnet per
+  request, so it does cost real money — see §6.)
+
+## 3. Request / response mapping
+
+Both modes call the same `postSearch()` helper and parse the same
+`SearchResponse` shape, so results, filters, and the assistant message render
+identically. The only differences are the URL and the request body:
+
+|                  | Deterministic (`/search`)         | Agent (`/search/agent`)                                              |
+| ---------------- | --------------------------------- | -------------------------------------------------------------------- |
+| URL              | `getSearchApiUrl(config.ai?.url)` | `getSearchApiUrl(config.ai?.url, { agent: true })` → base + `/agent` |
+| Body             | `{ query, previousQuery? }`       | `{ query, sessionId }`                                               |
+| Multi-turn state | client-owned (`previousQuery`)    | server-owned (`SessionStore`, keyed by `sessionId`)                  |
+| Response         | `SearchResponse`                  | `SearchResponse` (identical shape; `message` is the agent's prose)   |
+
+The base URL (env `NEXT_PUBLIC_SEARCH_API_URL` or `config.ai?.url`) ends in
+`/search`, so the agent URL is that with `/agent` appended.
+
+## 4. Session model
+
+`sessionId` is a `crypto.randomUUID()` generated **lazily on the first agent
+submission** and held in a ref for the lifetime of the provider (one
+research-view visit). The agent handles "reset"/new-topic turns server-side, so
+a single id per visit is sufficient; we deliberately do not try to detect a
+"fresh search" on the client.
+
+> **Secure-context requirement.** `crypto.randomUUID()` is only available in a
+> secure context (HTTPS, or `localhost`). All real deployments are HTTPS, but a
+> non-secure origin such as a bare `http://<LAN-IP>` dev server will throw on
+> submission. Use HTTPS or `localhost` when testing agent mode.
+
+## 5. Behavioral notes & known limitations
+
+> **Flag read timing.** The flag is read via `next/router` `router.query`, which
+> is empty until the router hydrates. In the (sub-second) window before
+> hydration, a submission would fall back to the deterministic `/search` path;
+> it self-corrects on the next turn. Acceptable for an opt-in experiment.
+
+Tracked separately:
+
+- **Markdown not formatted (#381).** The agent replies in markdown, but the
+  assistant message is rendered as plain `<Typography>` text, so formatting is
+  not applied. Out of scope here.
+- **Filter-chip removal (#382).** The chip × button uses the deterministic
+  `previousQuery` lookup and is left **as-is** in agent mode (it does not update
+  the agent's server-side state). Tracked for a proper fix.
+- **Persisted-history truncation (#380).** The backend currently applies stopgap
+  bounds on stored history; a coherent policy is tracked there.
+
+## 6. Why this is safe to ship
+
+Additive and opt-in: with no flag, behavior is exactly today's `/search`. The
+agent path is reachable only by explicitly adding `?agent=1`, and is rate-limited
+server-side. Nothing about the default experience changes.
+
+## 7. Next steps (epic #365)
+
+- Resolve #381 / #382 so agent mode reaches UX parity.
+- Streaming for perceived latency; DynamoDB `SessionStore` for prod persistence.
+- Frontend `session_id` plumbing to replace the `previousQuery` round-trip.
+- Promote agent to default once parity + confidence are reached.


### PR DESCRIPTION
Closes #383. Part of epic #365 (PR C).

## What

Points the existing conversational search UI at the new **`/search/agent`** endpoint (#379) behind a **URL feature flag** — no toggle UI, same UI as today.

- With **no flag**, behavior is exactly today's `/search` (deterministic pipeline, `previousQuery` round-trip).
- Adding **`?agent=1`** routes submissions to `/search/agent` with a server-owned session (`{ query, sessionId }`, no `previousQuery`).

Because `/search/agent` returns the same `SearchResponse` shape, results, filters, and the prompt window render unchanged (the agent's prose lands in the same `message` slot).

## Changes

- **`app/utils/searchApiUrl.ts`** — `getSearchApiUrl` gains an `{ agent }` option returning `base + /agent`.
- **`app/views/ResearchView/hooks/UseAgentMode/hook.ts`** (new) — `useAgentMode()`, single source of truth for the `?agent=1` flag (param name + enabled value as constants).
- **`app/views/ResearchView/artifact/form.tsx`** — `MultiTurnQueryProvider` reads the flag; in agent mode POSTs `{ query, sessionId }` (lazy `crypto.randomUUID()` held in a ref) and skips `previousQuery`. Default path unchanged.
- **`app/views/ResearchView/artifact/form.test.tsx`** — mock `next/router` (now required since the provider reads the flag), honor the agent option in the `getSearchApiUrl` mock, and add agent-mode coverage (posts to `/search/agent` with `sessionId`, no `previousQuery`; session id reused across turns).
- **`app/utils/searchApiUrl.test.ts`** (new) — unit tests for the helper.
- **`docs/DESIGN-agent-search-mode.md`** (new) — design note: enabling, request/response mapping, session model, secure-context + hydration notes, known limitations.

## Decisions

- `?agent=1`, **honored in all environments** (server-side rate limiting is the guard).
- Filter chips left **as-is** in agent mode → proper fix tracked in **#382**.
- Markdown rendering of replies is out of scope → **#381**.

## Verification

- `prettier` + `eslint` clean; `tsc --noEmit` clean.
- `jest` full suite: **144 passed, 10 skipped** (incl. 7 existing provider tests + 2 new agent-mode tests + helper tests).

## Review process

Claude implementation → `/simplify` (extracted `useAgentMode`, removed redundant test) → `/code-review` (high effort, 8 angles): caught and fixed a real regression — the new `useRouter()` call broke the existing `form.test.tsx`; added router mocks + agent-mode coverage. Remaining minor edges (secure-context `crypto.randomUUID`, Pages-Router hydration timing) are documented in the design note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)