### PR TITLE
feat: constrain agent reply markdown vocabulary + ignore backend/.venv in eslint (#381)

### DIFF
--- a/backend/concept_search/CONVERSATION_PROMPT.md
+++ b/backend/concept_search/CONVERSATION_PROMPT.md
@@ -118,3 +118,10 @@ covers the user's intent.
 Be concise. Summarize what you found or recorded (counts, key filters). When you
 asked a disambiguation question, wait for the answer. Don't dump raw rows — the
 UI shows the result table; your job is the conversation around it.
+
+**Formatting.** Your reply renders as markdown in a narrow chat panel. Use only:
+bold, italic, bullet or numbered lists, links, and inline `code` (good for study
+IDs, concept names, and facet values). Do not use headings — they render
+oversized in the panel; use bold for emphasis instead. The UI already shows the
+result table, so prefer prose or short lists; reserve a small markdown table for
+a brief side-by-side comparison, never for listing out results.

--- a/backend/concept_search/CONVERSATION_PROMPT.md
+++ b/backend/concept_search/CONVERSATION_PROMPT.md
@@ -121,7 +121,7 @@ UI shows the result table; your job is the conversation around it.
 
 **Formatting.** Your reply renders as markdown in a narrow chat panel. Use only:
 bold, italic, bullet or numbered lists, links, and inline `code` (good for study
-IDs, concept names, and facet values). Do not use headings — they render
-oversized in the panel; use bold for emphasis instead. The UI already shows the
+IDs, concept names, and facet values). Do not use headings (`#`, `##`) — they
+render oversized in the panel; use bold for emphasis instead. The UI already shows the
 result table, so prefer prose or short lists; reserve a small markdown table for
 a brief side-by-side comparison, never for listing out results.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ const config = [
   {
     ignores: [
       "**/node_modules/**",
+      "**/.venv/**",
       "**/out/**",
       "**/.next/**",
       "**/build/**",


### PR DESCRIPTION
Part 2 of #381 (the backend half). The rendering half is tracked separately in #387 (findable-ui, assigned to @frano-m).

## What changed

**1. Constrain the agent's reply markdown (`backend/concept_search/CONVERSATION_PROMPT.md`)**
Limits the conversation agent to formatting that renders well in the narrow chat panel: **bold, italic, bullet/numbered lists, links, inline `code`**. Bans headings (they render oversized — uses bold for emphasis instead) and discourages tables since the UI already shows the result table.

Live-verified with 4 real agent turns: no headings emitted, good use of bold/lists/inline code, tables only for small comparisons. (The model does occasionally use `---` rules + bold pseudo-headings to structure long replies — accepted as-is; captured as a styling note in #387.)

**2. Ignore `backend/.venv` in the ESLint flat config (`eslint.config.mjs`)** — closes #386
Incidental fix for a #376 regression: vendored JS inside the backend's uv virtualenv (sklearn, torch) was being linted by `eslint .`, producing ~354 errors that break the pre-commit hook for anyone running the backend in their checkout. `eslint .` was green in #376 CI only because the frontend job has no Python venv. One-line ignore; bundled here since it's tiny and unblocks backend commits, but it's separable to `main` if preferred.

## Mergeable independently of #387

This is non-breaking without the findable-ui rendering change. Until #387 lands, assistant replies render as raw text (findable-ui's `AssistantMessage` is a plain `<Typography>` with no markdown parsing and no `white-space: pre-wrap`), so markdown shows literally and newlines collapse. That's the pre-existing #381 behavior; this PR doesn't worsen it (slightly cleaner raw output — no oversized headings).

## Test plan
- [x] `eslint .` → 0 errors with `backend/.venv` present (was 354)
- [x] Pre-commit hooks (prettier + eslint + tsc) green on both commits
- [x] Live agent turns confirm the constrained formatting