### PR TITLE
chore: drop next-compose-plugins and clear `browserdebuginfointerminal` deprecation warning (#385)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,16 +1,16 @@
 import nextMDX from "@next/mdx";
-import withPlugins from "next-compose-plugins";
 
 const withMDX = nextMDX({ extension: /\.mdx?$/ });
 
-export default withPlugins(
-  [withMDX, { pageExtensions: ["md", "mdx", "ts", "tsx"] }],
-  {
-    basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
-    images: { unoptimized: true },
-    output: "export",
-    reactStrictMode: true,
-    staticPageGenerationTimeout: 120,
-    transpilePackages: ["@databiosphere/findable-ui"],
-  }
-);
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
+  images: { unoptimized: true },
+  output: "export",
+  pageExtensions: ["md", "mdx", "ts", "tsx"],
+  reactStrictMode: true,
+  staticPageGenerationTimeout: 120,
+  transpilePackages: ["@databiosphere/findable-ui"],
+};
+
+export default withMDX(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "ky": "^1.7.2",
         "match-sorter": "^6.3.1",
         "next": "^16",
-        "next-compose-plugins": "^2.2.1",
         "next-mdx-remote": "^6",
         "next-sitemap": "^4.2.3",
         "react": "^19.2.3",
@@ -15451,12 +15450,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/next-compose-plugins": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz",
-      "integrity": "sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==",
-      "license": "MIT"
     },
     "node_modules/next-mdx-remote": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ky": "^1.7.2",
     "match-sorter": "^6.3.1",
     "next": "^16",
-    "next-compose-plugins": "^2.2.1",
     "next-mdx-remote": "^6",
     "next-sitemap": "^4.2.3",
     "react": "^19.2.3",


### PR DESCRIPTION
## Summary

Closes #385

Follow-up from the Next.js 16 upgrade (#372 / PR #376). Removes the abandoned `next-compose-plugins@2.2.1` dependency, which was spreading a legacy `defaultConfig` (with a stale `experimental.browserDebugInfoInTerminal` key) into the resolved config and tripping Next 16's deprecation notice on every `next dev` / `next build`.

`@next/mdx` is now composed directly (the modern documented idiom), and `pageExtensions` is folded into the config object where Next 16 expects it.

## Changes

- Removed `next-compose-plugins` from `next.config.mjs`, `package.json`, and `package-lock.json`
- Rewrote `next.config.mjs` to wrap the config with `withMDX(nextConfig)` directly

## Verification

| Check | Result |
|---|---|
| Warning reproduced **before** change (`next dev`) | ⚠️ `experimental.browserDebugInfoInTerminal` printed |
| Warning **after** change (`next dev`) | ✅ Gone |
| Warning during `build:prod` | ✅ Gone |
| Static export build (`build:prod`) | ✅ succeeds (exit 0, sitemaps generated) |
| MDX pages render + export | ✅ `/about`, `/guides`, `/privacy` exported with content |
| Prettier / ESLint | ✅ clean |

Root cause confirmed as suspected in the issue: `next-compose-plugins` was the source of the injected `experimental.*` key.

## Acceptance

- [x] `next-compose-plugins` removed from `package.json` + `next.config.mjs`
- [x] No `browserDebugInfoInTerminal` deprecation warning on `next dev` / `next build`
- [x] MDX pages render + static export build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)