### PR TITLE
fix: render assistant markdown in findable-ui assistantmessage (part 1 of #381)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ncpi-dataset-catalog",
       "version": "0.19.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^54.0.0",
+        "@databiosphere/findable-ui": "^55.0.0",
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11",
         "@emotion/styled": "^11.14.1",
@@ -907,9 +907,9 @@
       "license": "MIT"
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "54.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-54.1.0.tgz",
-      "integrity": "sha512-zN1hqsrPHc5gT6orAVUDWw7clGua5lISA/r3dkK2oyCL+XfIUqTh4TiTamHuK77NbJKraW7XRFejViY1imzP/w==",
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-55.0.0.tgz",
+      "integrity": "sha512-BkzNX1R76mdY8hvdLGFaDNhi1+H7iq7PwRnGNqTYH82YaRBmQOWPozojkLqsesu8Nlg9JL6V+59cqFX1941iuQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.13.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "unlink-findable": "../findable-ui/scripts/unlink.sh"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^54.0.0",
+    "@databiosphere/findable-ui": "^55.0.0",
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11",
     "@emotion/styled": "^11.14.1",


### PR DESCRIPTION
## Summary

Closes #387 (Part 1 of #381) — the rendering half of the assistant-markdown fix.

The fix lives entirely in **findable-ui**; this repo only consumes it. `AssistantMessage` now renders `message.response.message` through a sanitized `MarkdownRenderer` (remark-parse + remark-gfm + remark-rehype + rehype-raw + **rehype-sanitize** + rehype-react) instead of a plain `<Typography>`, with sensible default styling for the narrow chat panel (lists, `<hr>`, heading sizing) baked in.

## Change

- Bump `@databiosphere/findable-ui` `^54.0.0` → `^55.0.0`.
- No app code changes — this repo doesn't override the `ResearchView → Assistant → Messages → AssistantMessage` chain, so it picks up the fix automatically. The library exposes a stable `MARKDOWN_CLASS_NAME` if we ever want to override styles later.

## findable-ui 55.0.0 breaking change

The only breaking change (removed `login/components/button` export) is **not used** anywhere in this repo — verified.

## Verification

- `npm run build:dev` ✓
- `npm run lint` ✓ (0 errors; only pre-existing TODO warnings)
- `npm run check-format` ✓
- `npm test` ✓ (155 passed)
- Content stays on the `rehype-sanitize` path — no unsanitized `rehype-raw` passthrough for LLM-generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1366" height="1163" alt="image" src="https://github.com/user-attachments/assets/e9e1261b-681a-48be-bced-65c3e0bdfb4b" />
