### PR TITLE
fix: filter-chip removal in agent mode via POST /search/agent/filter (#382)

### DIFF
--- a/app/views/ResearchView/artifact/form.test.tsx
+++ b/app/views/ResearchView/artifact/form.test.tsx
@@ -387,6 +387,96 @@ describe("MultiTurnQueryProvider removeFilter", () => {
   });
 });
 
+describe("MultiTurnQueryProvider removeFilter (agent mode)", () => {
+  const originalRandomUUID = Object.getOwnPropertyDescriptor(
+    crypto,
+    "randomUUID"
+  );
+
+  afterEach(() => {
+    if (originalRandomUUID) {
+      Object.defineProperty(crypto, "randomUUID", originalRandomUUID);
+    } else {
+      delete (crypto as { randomUUID?: unknown }).randomUUID;
+    }
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChatState.state.messages = [];
+    mockRouter.query = { agent: "1" };
+    Object.defineProperty(crypto, "randomUUID", {
+      configurable: true,
+      value: () => "uuid-1",
+    });
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          intent: "study",
+          message: "Removed.",
+          query: { intent: "study", mentions: [], message: null },
+          timing: { lookupMs: 0, pipelineMs: 0, totalMs: 0 },
+        }),
+      ok: true,
+      status: 200,
+    });
+  });
+
+  /**
+   * Renders both contexts from a single provider instance.
+   * @returns Hook result with onSubmit and removeFilter.
+   */
+  function renderBoth() {
+    return renderHook(
+      () => ({
+        multiTurn: useContext(MultiTurnContext),
+        query: useContext(QueryContext),
+      }),
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <MultiTurnQueryProvider>{children}</MultiTurnQueryProvider>
+        ),
+      }
+    );
+  }
+
+  it("posts to the agent filter endpoint with sessionId, no previousQuery", async () => {
+    const { result } = renderBoth();
+
+    // Establish the agent session with a first submission.
+    await act(async () => {
+      await result.current.query.onSubmit(
+        mockFormEvent(),
+        { query: "diabetes studies" },
+        defaultOptions
+      );
+    });
+
+    await act(async () => {
+      result.current.multiTurn.removeFilter("focus", "DM");
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    const calls = (global.fetch as jest.Mock).mock.calls;
+    expect(calls).toHaveLength(2);
+    const [calledUrl, init] = calls[1];
+    expect(calledUrl).toBe("https://test-api/search/agent/filter");
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({ facet: "focus", sessionId: "uuid-1", value: "DM" });
+  });
+
+  it("is a no-op before an agent session exists", async () => {
+    const { result } = renderBoth();
+
+    await act(async () => {
+      result.current.multiTurn.removeFilter("focus", "DM");
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
 describe("MultiTurnQueryProvider onSubmit (agent mode)", () => {
   // jsdom does not implement crypto.randomUUID; stub it with incrementing ids
   // so the "reuse" test can prove the session id is generated once, not per turn.

--- a/app/views/ResearchView/artifact/form.tsx
+++ b/app/views/ResearchView/artifact/form.tsx
@@ -223,6 +223,20 @@ export function MultiTurnQueryProvider({
 
   const removeFilter = useCallback(
     (facet: string, value: string): void => {
+      if (agentMode) {
+        // Agent mode: conversation state lives server-side, keyed by sessionId.
+        // Ask the backend to drop the value from the session's query — the
+        // deterministic previousQuery round-trip below would bypass it.
+        if (!sessionIdRef.current || !submitUrl) return;
+        dispatch.onSetStatus(true);
+        postSearch(
+          `${submitUrl}/filter`,
+          { facet, sessionId: sessionIdRef.current, value },
+          abortRef,
+          dispatch
+        );
+        return;
+      }
       if (!lastQueryRef.current || !url) return;
       const filtered = lastQueryRef.current.mentions
         .map((m: Mention) => {
@@ -247,7 +261,7 @@ export function MultiTurnQueryProvider({
         }
       });
     },
-    [dispatch, url]
+    [agentMode, dispatch, submitUrl, url]
   );
 
   return (

--- a/backend/concept_search/api.py
+++ b/backend/concept_search/api.py
@@ -20,6 +20,7 @@ from fastapi.responses import JSONResponse
 from .api_models import (
     DemographicCategory,
     DemographicDistribution,
+    SearchAgentFilterRequest,
     SearchAgentRequest,
     SearchRequest,
     SearchResponse,
@@ -36,9 +37,10 @@ from .conversation_agent import (
     run_conversation,
     serialize_history,
 )
-from .index import get_index
+from .index import ConceptIndex, get_index
 from .models import (
     ConversationMessage,
+    Facet,
     QueryModel,
     ResolvedMention,
     RouteRemove,
@@ -383,6 +385,93 @@ def _timeout_response(elapsed_ms: int, message: str) -> SearchResponse:
     )
 
 
+def _build_response_message(
+    query_model: QueryModel,
+    query_structure: QueryStructure | None,
+    studies: list,
+    variable_rows: list,
+    total_variable_count: int,
+    index: ConceptIndex,
+) -> str | None:
+    """Build the deterministic response message for a lookup result.
+
+    Shared by ``/search`` and ``/search/agent/filter`` (``/search/agent`` uses
+    the agent's own reply instead). Also populates ``query_structure.summary``
+    as a side effect when it is empty.
+
+    Args:
+        query_model: The resolved query model that was executed.
+        query_structure: Structured query built from the model (may be None).
+        studies: Matched studies from execution.
+        variable_rows: Matched variable rows from execution.
+        total_variable_count: Total matched variable count.
+        index: The concept index (for empty-result diagnosis).
+
+    Returns:
+        The message to display, or None when there is nothing to say.
+    """
+    intent = query_model.intent
+    if query_model.message:
+        # Disambiguation/removal — keep existing message.
+        # Still populate query_structure.summary independently so it
+        # always describes the query, not the disambiguation text.
+        message = query_model.message
+        # Populate summary independently — but skip for intent=="ambiguous"
+        # where lookup was skipped and counts would be misleading (0).
+        if query_structure is not None and not query_structure.summary and intent != "ambiguous":
+            build_message(
+                query_structure,
+                len(studies),
+                total_variable_count,
+                query_model,
+            )
+        return message
+    if not studies and not variable_rows and query_model.mentions:
+        # Zero results — recovery guidance.
+        # Set summary to just the header line (e.g. "No studies found where…").
+        message = diagnose_empty_results(query_model, index)
+        if query_structure is not None and not query_structure.summary:
+            query_structure.summary = message.split("\n", 1)[0]
+        return message
+    if query_model.mentions:
+        # Normal results — build_message sets summary as side effect
+        return build_message(
+            query_structure,
+            len(studies),
+            total_variable_count,
+            query_model,
+        )
+    return None
+
+
+def _remove_filter_value(query: QueryModel, facet: Facet, value: str) -> QueryModel:
+    """Drop a single facet value from the query, removing emptied mentions.
+
+    Value-granular to match filter-chip clicks: a mention with several OR-ed
+    values keeps the rest; a mention left with no values is dropped entirely.
+    Any stale clarification message is cleared — the result reflects a plain
+    lookup, not a pending disambiguation.
+
+    Args:
+        query: The query model to remove the value from (not mutated).
+        facet: Facet of the chip that was removed.
+        value: Canonical value of the chip that was removed.
+
+    Returns:
+        A new QueryModel without the given facet value.
+    """
+    mentions: list[ResolvedMention] = []
+    for mention in query.mentions:
+        if mention.facet != facet:
+            mentions.append(mention)
+            continue
+        values = [v for v in mention.values if v != value]
+        if not values:
+            continue
+        mentions.append(mention.model_copy(update={"values": values}))
+    return query.model_copy(update={"mentions": mentions, "message": None})
+
+
 def _rate_limit_response(client_ip: str, query: str) -> JSONResponse:
     """Log a rate-limit hit and build the 429 response (shared by both search paths)."""
     _log_json(event="rate_limited", ip=client_ip, query=query)
@@ -463,36 +552,14 @@ async def search(
 
     # Build structured query and response message
     query_structure = build_query_structure(query_model, index)
-    if query_model.message:
-        # Disambiguation/removal — keep existing message.
-        # Still populate query_structure.summary independently so it
-        # always describes the query, not the disambiguation text.
-        message = query_model.message
-        # Populate summary independently — but skip for intent=="ambiguous"
-        # where lookup was skipped and counts would be misleading (0).
-        if query_structure is not None and not query_structure.summary and intent != "ambiguous":
-            build_message(
-                query_structure,
-                len(studies),
-                total_variable_count,
-                query_model,
-            )
-    elif not studies and not variable_rows and query_model.mentions:
-        # Zero results — recovery guidance.
-        # Set summary to just the header line (e.g. "No studies found where…").
-        message = diagnose_empty_results(query_model, index)
-        if query_structure is not None and not query_structure.summary:
-            query_structure.summary = message.split("\n", 1)[0]
-    elif query_model.mentions:
-        # Normal results — build_message sets summary as side effect
-        message = build_message(
-            query_structure,
-            len(studies),
-            total_variable_count,
-            query_model,
-        )
-    else:
-        message = None
+    message = _build_response_message(
+        query_model,
+        query_structure,
+        studies,
+        variable_rows,
+        total_variable_count,
+        index,
+    )
 
     # Convert internal QueryStructure to API model
     api_query_structure = _to_api_query_structure(query_structure)
@@ -655,6 +722,97 @@ async def search_agent(
         total_studies=len(execution.studies),
         total_variables=execution.total_variable_count,
         pipeline_ms=pipeline_ms,
+        lookup_ms=lookup_ms,
+    )
+    return response
+
+
+@app.post("/search/agent/filter", response_model=SearchResponse)
+async def search_agent_filter(
+    request: SearchAgentFilterRequest, fastapi_request: Request
+) -> SearchResponse | JSONResponse:
+    """Structured filter removal for agent mode (#382).
+
+    Deterministic sibling of ``/search/agent`` — no LLM turn. Drops one facet
+    value from the session's persisted query state, re-runs the lookup, and
+    saves the session. The next conversational turn sees the updated filters
+    because the state preamble is rebuilt from ``state.query`` each turn.
+    """
+    client_ip = _get_client_ip(fastapi_request)
+    if not await _rate_limiter.is_allowed(client_ip):
+        return _rate_limit_response(client_ip, f"remove {request.facet.value}={request.value}")
+
+    _log_json(
+        event="agent_filter_request",
+        session_id=request.session_id,
+        facet=request.facet.value,
+        value=request.value,
+    )
+    t_start = time.monotonic()
+
+    store = get_session_store()
+    try:
+        state = await store.get(request.session_id) or SessionState()
+    except Exception as exc:  # noqa: BLE001 — a store read failure is retryable, not a 500
+        _log_json(
+            event="agent_store_error",
+            op="get",
+            session_id=request.session_id,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        elapsed_ms = int((time.monotonic() - t_start) * 1000)
+        return _timeout_response(elapsed_ms, "Something went wrong — please try again.")
+
+    query_model = _remove_filter_value(state.query or QueryModel(), request.facet, request.value)
+
+    index = get_index()
+    execution = execute_query_model(query_model, index)
+    t_lookup = time.monotonic()
+    lookup_ms = int((t_lookup - t_start) * 1000)
+
+    query_structure = build_query_structure(query_model, index)
+    message = _build_response_message(
+        query_model,
+        query_structure,
+        execution.studies,
+        execution.variable_rows,
+        execution.total_variable_count,
+        index,
+    )
+    response = SearchResponse(
+        intent=query_model.intent,
+        message=message,
+        query=query_model,
+        query_structure=_to_api_query_structure(query_structure),
+        studies=[_build_study_summary(s) for s in execution.studies],
+        timing=SearchTiming(lookup_ms=lookup_ms, pipeline_ms=0, total_ms=lookup_ms),
+        total_studies=len(execution.studies),
+        total_variables=execution.total_variable_count,
+        variables=[_build_variable_result(r) for r in execution.variable_rows],
+    )
+
+    # Persist the updated query so the next agent turn reasons over it.
+    state.query = query_model
+    try:
+        await store.save(request.session_id, state)
+    except Exception as exc:  # noqa: BLE001 — the response is built; a persist failure must not 500
+        _log_json(
+            event="agent_store_error",
+            op="save",
+            session_id=request.session_id,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+
+    _log_json(
+        event="agent_filter_response",
+        session_id=request.session_id,
+        facet=request.facet.value,
+        value=request.value,
+        intent=query_model.intent,
+        total_studies=len(execution.studies),
+        total_variables=execution.total_variable_count,
         lookup_ms=lookup_ms,
     )
     return response

--- a/backend/concept_search/api_models.py
+++ b/backend/concept_search/api_models.py
@@ -87,6 +87,23 @@ class SearchAgentRequest(BaseModel):
         return self
 
 
+class SearchAgentFilterRequest(BaseModel):
+    """Structured filter removal for the agentic ``/search/agent/filter`` endpoint.
+
+    Sent when the user clicks the × on a filter chip in agent mode. This is a
+    deterministic operation — no LLM turn: the backend drops the value from the
+    session's persisted query state and re-runs the lookup. The next
+    conversational turn sees the updated filters via the state preamble, which
+    is rebuilt from the persisted query each turn.
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    facet: Facet
+    session_id: str = Field(min_length=1, max_length=128)
+    value: str = Field(min_length=1, max_length=500)
+
+
 class DemographicCategory(BaseModel):
     """A single category within a demographic distribution."""
 

--- a/backend/tests/test_api_agent.py
+++ b/backend/tests/test_api_agent.py
@@ -9,6 +9,7 @@ harnesses (``eval_agent_conversation`` / ``eval_agent_decision``).
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -17,7 +18,7 @@ from fastapi.testclient import TestClient
 from concept_search import api as api_module
 from concept_search.api import app
 from concept_search.models import Facet, QueryModel, ResolvedMention
-from concept_search.session_store import InMemorySessionStore
+from concept_search.session_store import InMemorySessionStore, SessionState
 
 
 def _study(title: str = "Study A", db_gap_id: str = "phs000001") -> dict:
@@ -63,12 +64,42 @@ def _recording_run(seen: list[list[str]]):
     return fake_run
 
 
+def _multi_value_query() -> QueryModel:
+    """A query with a two-value focus mention plus a platform mention."""
+    return QueryModel(
+        intent="study",
+        mentions=[
+            ResolvedMention(
+                facet=Facet.FOCUS,
+                original_text="diabetes",
+                values=["Diabetes Mellitus", "Diabetes Mellitus, Type 2"],
+            ),
+            ResolvedMention(
+                facet=Facet.PLATFORM,
+                original_text="anvil",
+                values=["AnVIL"],
+            ),
+        ],
+    )
+
+
+def _seed_session(store: InMemorySessionStore, session_id: str, query: QueryModel) -> None:
+    """Persist a session with the given committed query state."""
+    asyncio.run(store.save(session_id, SessionState(query=query)))
+
+
 @pytest.fixture
-def agent_client():
-    """A TestClient backed by a fresh in-memory session store per test."""
+def agent_store():
+    """A fresh in-memory session store patched into the API module."""
     store = InMemorySessionStore()
     with patch("concept_search.api.get_session_store", return_value=store):
-        yield TestClient(app, raise_server_exceptions=False)
+        yield store
+
+
+@pytest.fixture
+def agent_client(agent_store):
+    """A TestClient backed by a fresh in-memory session store per test."""
+    yield TestClient(app, raise_server_exceptions=False)
 
 
 class TestSearchAgentEndpoint:
@@ -238,3 +269,166 @@ class TestSearchAgentEndpoint:
         client = TestClient(app, raise_server_exceptions=False)
         resp = client.post("/search/agent", json={"query": "   ", "sessionId": "s1"})
         assert resp.status_code == 422
+
+
+class TestSearchAgentFilterEndpoint:
+    """HTTP-level tests for POST /search/agent/filter (structured chip removal)."""
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_removes_single_value_keeps_mention(
+        self, mock_index, mock_run, agent_store, agent_client
+    ) -> None:
+        """Removing one of two OR-ed values keeps the mention with the rest — no LLM call."""
+        mock_index.return_value.query_studies.return_value = [_study()]
+        mock_index.return_value.stats = {}
+        _seed_session(agent_store, "s1", _multi_value_query())
+
+        resp = agent_client.post(
+            "/search/agent/filter",
+            json={"facet": "focus", "sessionId": "s1", "value": "Diabetes Mellitus"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        focus = [m for m in data["query"]["mentions"] if m["facet"] == "focus"]
+        assert len(focus) == 1
+        assert focus[0]["values"] == ["Diabetes Mellitus, Type 2"]
+        mock_run.assert_not_called()
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_removing_last_value_drops_mention(
+        self, mock_index, mock_run, agent_store, agent_client
+    ) -> None:
+        """A mention emptied by the removal is dropped entirely."""
+        mock_index.return_value.query_studies.return_value = [_study()]
+        mock_index.return_value.stats = {}
+        _seed_session(agent_store, "s1", _multi_value_query())
+
+        resp = agent_client.post(
+            "/search/agent/filter",
+            json={"facet": "platform", "sessionId": "s1", "value": "AnVIL"},
+        )
+
+        assert resp.status_code == 200
+        facets = [m["facet"] for m in resp.json()["query"]["mentions"]]
+        assert facets == ["focus"]
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_removal_is_persisted_for_next_agent_turn(
+        self, mock_index, mock_run, agent_store, agent_client
+    ) -> None:
+        """The next /search/agent turn is handed the query state minus the removed filter."""
+        mock_index.return_value.query_studies.return_value = []
+        mock_index.return_value.stats = {}
+        _seed_session(agent_store, "s1", _multi_value_query())
+
+        seen: list[list[str]] = []
+        mock_run.side_effect = _recording_run(seen)
+
+        r1 = agent_client.post(
+            "/search/agent/filter",
+            json={"facet": "focus", "sessionId": "s1", "value": "Diabetes Mellitus, Type 2"},
+        )
+        r2 = agent_client.post("/search/agent", json={"query": "and BMI", "sessionId": "s1"})
+
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        # The agent turn saw the persisted state with the platform mention intact
+        # and the focus mention still present (one value remained).
+        assert seen == [["diabetes", "anvil"]]
+        state = asyncio.run(agent_store.get("s1"))
+        assert state is not None
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_unknown_session_returns_empty_query(
+        self, mock_index, mock_run, agent_store, agent_client
+    ) -> None:
+        """A filter removal on an unknown session degrades to an empty query, not an error."""
+        mock_index.return_value.query_studies.return_value = []
+        mock_index.return_value.stats = {}
+
+        resp = agent_client.post(
+            "/search/agent/filter",
+            json={"facet": "focus", "sessionId": "missing", "value": "Diabetes Mellitus"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["query"]["mentions"] == []
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_store_get_failure_returns_friendly_error(self, mock_index, mock_run) -> None:
+        """A session-store read failure surfaces a retryable message, not a 500."""
+        mock_index.return_value.stats = {}
+        store = InMemorySessionStore()
+        store.get = AsyncMock(side_effect=RuntimeError("dynamodb unavailable"))
+
+        with patch("concept_search.api.get_session_store", return_value=store):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post(
+                "/search/agent/filter",
+                json={"facet": "focus", "sessionId": "s1", "value": "x"},
+            )
+
+        assert resp.status_code == 200
+        assert "went wrong" in resp.json()["message"].lower()
+
+    @patch("concept_search.api.run_conversation")
+    @patch("concept_search.api.get_index")
+    def test_store_save_failure_still_returns_response(self, mock_index, mock_run) -> None:
+        """A persist failure after the response is built does not fail the request."""
+        mock_index.return_value.query_studies.return_value = [_study()]
+        mock_index.return_value.stats = {}
+        store = InMemorySessionStore()
+        _seed_session(store, "s1", _multi_value_query())
+        store.save = AsyncMock(side_effect=RuntimeError("dynamodb unavailable"))
+
+        with patch("concept_search.api.get_session_store", return_value=store):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post(
+                "/search/agent/filter",
+                json={"facet": "platform", "sessionId": "s1", "value": "AnVIL"},
+            )
+
+        assert resp.status_code == 200
+        facets = [m["facet"] for m in resp.json()["query"]["mentions"]]
+        assert facets == ["focus"]
+
+    @patch("concept_search.api.get_index")
+    def test_invalid_facet_is_rejected(self, mock_index) -> None:
+        """An unknown facet fails validation (422)."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/search/agent/filter",
+            json={"facet": "nonsense", "sessionId": "s1", "value": "x"},
+        )
+        assert resp.status_code == 422
+
+    @patch("concept_search.api.get_index")
+    def test_missing_session_id_is_rejected(self, mock_index) -> None:
+        """A request without a session id fails validation (422)."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/search/agent/filter", json={"facet": "focus", "value": "x"})
+        assert resp.status_code == 422
+
+    @patch("concept_search.api.get_index")
+    def test_rate_limit_returns_429(self, mock_index) -> None:
+        """A rate-limited client gets a 429 before any store access."""
+        with (
+            patch.object(
+                api_module._rate_limiter, "is_allowed", new=AsyncMock(return_value=False)
+            ),
+            patch("concept_search.api.get_session_store") as mock_store,
+        ):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post(
+                "/search/agent/filter",
+                json={"facet": "focus", "sessionId": "s1", "value": "x"},
+            )
+
+        assert resp.status_code == 429
+        mock_store.assert_not_called()


### PR DESCRIPTION
Closes #382. Part of epic #365.

## Problem

In agent mode (`?agent=1`), clicking the × on a filter chip called `removeFilter()`, which always re-submitted via the deterministic `/search` `previousQuery` round-trip — bypassing the agent's server-side session entirely. The chip disappeared from the results view, but the agent's persisted `state.query` still contained the filter, so the next conversational turn silently reasoned over stale filters.

## Fix

**Backend — new `POST /search/agent/filter`** (deterministic sibling of `/search/agent`, no LLM turn):
- Request: `{sessionId, facet, value}` (`SearchAgentFilterRequest`, facet validated against the `Facet` enum).
- Loads the session, drops the value from `state.query` (**value-granular**, matching chip granularity: a mention with several OR-ed values keeps the rest; an emptied mention is dropped), re-runs `execute_query_model`, saves the session, and returns a full `SearchResponse`.
- Because the state preamble is rebuilt from `state.query` on every agent turn, the next NL turn sees the removal with no history rewrite.
- Mirrors `/search/agent`'s store get/save hardening (#402) and rate limiting; message text reuses the deterministic `/search` message logic, extracted into a shared `_build_response_message()` helper (behavior-preserving refactor of `/search`).

**Frontend — `removeFilter` branches on agent mode:**
- Agent mode: `POST {base}/agent/filter` with `{facet, sessionId, value}` — no `previousQuery`, no `lastQueryRef` mutation; the response flows through the existing `postSearch` → `onSetMessage` path so chips and results refresh as before.
- Non-agent mode: unchanged `previousQuery` round-trip.

With this, **no agent-mode code path sends `previousQuery`** (the remaining `lastQueryRef` removal is gated on promote-to-default, per #382).

## Tests

- Backend: 9 new endpoint tests in `test_api_agent.py` (value-granular remove, emptied-mention drop, persistence visible to the next `/search/agent` turn, unknown session, store get/save failures, validation 422s, rate limit 429). Full suite: 425 passed.
- Frontend: 2 new Jest tests (agent-mode filter POST shape; no-op before a session exists). Suite: 12 passed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)