### PR TITLE
chore: untrack next-env.d.ts; typegen before tsc (#406)

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -16,7 +16,7 @@ jobs:
           npm ci
           npm run check-format
           npm run lint
-          npx tsc --noEmit
+          npm run typecheck
           cd catalog-build
           npm ci
           npx tsc --noEmit

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ node_modules
 
 # next.js
 /.next/
+next-env.d.ts
 /out/
 
 # production

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,11 +11,11 @@ npm run check-format ||
 npm run lint ||
 (
         echo '🤔  ESLint Check Failed. Make the required changes listed above, add changes and try to commit again.'
-        false; 
+        false;
 )
 
 # Check TypeScript
-npx tsc --noEmit ||
+npm run typecheck ||
 (
 	echo 'TypeScript compile failed';
 	false;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postbuild": "next-sitemap --config next-sitemap.config.mjs",
     "start": "npx serve out",
     "lint": "eslint .",
+    "typecheck": "next typegen && tsc --noEmit",
     "check-format": "prettier --check .",
     "prepare": "husky",
     "test": "jest --watch",


### PR DESCRIPTION
Closes #406. Follow-up housekeeping from #405.

## What changed

- **`next-env.d.ts` is no longer tracked** (gitignored + `git rm --cached`). Next 16 rewrites it with mode-dependent content — `next dev` points it at `.next/dev/types/routes.d.ts`, `next build` at `.next/types/routes.d.ts` — so the tracked copy churned in `git status` after every dev session and flipped back on every build. Current Next guidance (and create-next-app's default .gitignore) is to not commit it.
- **New `typecheck` npm script**: `next typegen && tsc --noEmit`. `next typegen` (Next 15.5+) regenerates `next-env.d.ts` and the route types in seconds without a build, so typechecking works on fresh checkouts where the file no longer exists.
- **Pre-commit hook and CI** now run `npm run typecheck` instead of bare `npx tsc --noEmit` (which would fail on a fresh CI checkout without the generated file). The `catalog-build` tsc step is untouched — separate tsconfig, no Next types.

## Verification

- Fresh-checkout simulation: deleted `next-env.d.ts` and `.next/`, ran `npm run typecheck` → file regenerated, compile passes.
- Dev-churn simulation: wrote the `next dev` variant of the file → `git status` no longer reports it.
- The commit on this branch ran the new pre-commit hook end-to-end (typegen + tsc pass visible in hook output).
- Prettier passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)