### PR TITLE
chore: remove deprecated /search/agent* aliases (#413)

### DIFF
--- a/backend/concept_search/api.py
+++ b/backend/concept_search/api.py
@@ -371,9 +371,6 @@ _MAX_SESSION_MESSAGES = 50  # user/assistant text turns retained in the persiste
 
 
 @app.post("/search", response_model=SearchResponse)
-# Deprecated alias so a previously-deployed frontend keeps working during the
-# rename cutover; remove once the frontend is on /search (follow-up).
-@app.post("/search/agent", response_model=SearchResponse, include_in_schema=False)
 async def search(
     request: SearchRequest, fastapi_request: Request
 ) -> SearchResponse | JSONResponse:
@@ -493,8 +490,6 @@ async def search(
 
 
 @app.post("/search/filter", response_model=SearchResponse)
-# Deprecated alias; remove once the frontend is on /search/filter (follow-up).
-@app.post("/search/agent/filter", response_model=SearchResponse, include_in_schema=False)
 async def search_filter(
     request: SearchFilterRequest, fastapi_request: Request
 ) -> SearchResponse | JSONResponse:

--- a/backend/tests/test_api_agent.py
+++ b/backend/tests/test_api_agent.py
@@ -127,21 +127,6 @@ class TestSearchAgentEndpoint:
 
     @patch("concept_search.api.run_conversation")
     @patch("concept_search.api.get_index")
-    def test_deprecated_agent_alias_still_routes(self, mock_index, mock_run, agent_client) -> None:
-        """The deprecated /search/agent alias routes to the same handler.
-
-        Kept temporarily so a previously-deployed frontend survives the rename
-        cutover; remove with the alias once the frontend is on /search.
-        """
-        mock_index.return_value.query_studies.return_value = []
-        mock_index.return_value.stats = {}
-        mock_run.return_value = ("ok", _query(), [])
-
-        resp = agent_client.post("/search/agent", json={"query": "x", "sessionId": "s1"})
-        assert resp.status_code == 200
-
-    @patch("concept_search.api.run_conversation")
-    @patch("concept_search.api.get_index")
     def test_store_get_failure_returns_friendly_error(self, mock_index, mock_run) -> None:
         """A session-store read failure surfaces a retryable message, not a 500."""
         mock_index.return_value.query_studies.return_value = []
@@ -310,26 +295,6 @@ class TestSearchAgentFilterEndpoint:
         assert len(focus) == 1
         assert focus[0]["values"] == ["Diabetes Mellitus, Type 2"]
         mock_run.assert_not_called()
-
-    @patch("concept_search.api.run_conversation")
-    @patch("concept_search.api.get_index")
-    def test_deprecated_agent_filter_alias_still_routes(
-        self, mock_index, mock_run, agent_store, agent_client
-    ) -> None:
-        """The deprecated /search/agent/filter alias routes to the same handler.
-
-        Kept for the rename cutover; remove with the alias once the frontend is
-        on /search/filter.
-        """
-        mock_index.return_value.query_studies.return_value = []
-        mock_index.return_value.stats = {}
-        _seed_session(agent_store, "s1", _multi_value_query())
-
-        resp = agent_client.post(
-            "/search/agent/filter",
-            json={"facet": "focus", "sessionId": "s1", "value": "Diabetes Mellitus"},
-        )
-        assert resp.status_code == 200
 
     @patch("concept_search.api.run_conversation")
     @patch("concept_search.api.get_index")

--- a/docs/DESIGN-agent-search-mode.md
+++ b/docs/DESIGN-agent-search-mode.md
@@ -1,6 +1,6 @@
 # Design Note: Agent Search Mode (`?agent=1`)
 
-> Status: DRAFT — Jun 2026
+> Status: SUPERSEDED (Jul 2026) — originally DRAFT, Jun 2026
 > Refs: epic #365 · backend endpoint #379 · this PR #383 · follow-ups #381 (markdown), #382 (filter chips), #380 (history)
 
 > **⚠️ SUPERSEDED (Jul 2026, #410/#412).** This note describes the original

--- a/docs/DESIGN-agent-search-mode.md
+++ b/docs/DESIGN-agent-search-mode.md
@@ -3,6 +3,14 @@
 > Status: DRAFT — Jun 2026
 > Refs: epic #365 · backend endpoint #379 · this PR #383 · follow-ups #381 (markdown), #382 (filter chips), #380 (history)
 
+> **⚠️ SUPERSEDED (Jul 2026, #410/#412).** This note describes the original
+> *opt-in* rollout — the `?agent=1` flag, the deterministic `/search` pipeline as
+> the default, and the agent behind `/search/agent`. Agent search has since been
+> promoted to the **default and only** search path: the deterministic pipeline,
+> the `?agent=1` flag, and the `previousQuery` round-trip were removed, and the
+> orchestrator now serves **`POST /search`** (+ **`POST /search/filter`** for chip
+> removal). Endpoint/flow references below are historical.
+
 ---
 
 ## 1. Context

--- a/docs/DESIGN-agent-search-mode.md
+++ b/docs/DESIGN-agent-search-mode.md
@@ -4,7 +4,7 @@
 > Refs: epic #365 · backend endpoint #379 · this PR #383 · follow-ups #381 (markdown), #382 (filter chips), #380 (history)
 
 > **⚠️ SUPERSEDED (Jul 2026, #410/#412).** This note describes the original
-> *opt-in* rollout — the `?agent=1` flag, the deterministic `/search` pipeline as
+> _opt-in_ rollout — the `?agent=1` flag, the deterministic `/search` pipeline as
 > the default, and the agent behind `/search/agent`. Agent search has since been
 > promoted to the **default and only** search path: the deterministic pipeline,
 > the `?agent=1` flag, and the `previousQuery` round-trip were removed, and the


### PR DESCRIPTION
Closes #413. Follow-up to #412.

Removes the two schema-hidden alias routes (`/search/agent`, `/search/agent/filter`) and their guard tests. These were kept only to let the previously-deployed frontend survive the backend-first rename cutover.

## ⚠️ Deploy gate
**Do not merge/deploy until the prod frontend is confirmed serving from `/search`.** Removing the aliases while any client still posts to `/search/agent*` would 404 those requests. Once prod is fully on `/search`, this is safe and needs only a backend deploy (no frontend change).

## Verification
- No `/search/agent` references remain in **code** (grep clean). The historical design note `docs/DESIGN-agent-search-mode.md` retains references and is now marked **superseded** (its endpoint refs are historical).
- `make format`/`make lint` clean; **386 backend tests pass**

Refs #410, #412.