### PR TITLE
fix: home-page search 422 — hoist MultiTurnQueryProvider so all entry points send sessionId (#415)

### DIFF
--- a/app/views/ResearchView/artifact/form.test.tsx
+++ b/app/views/ResearchView/artifact/form.test.tsx
@@ -17,6 +17,10 @@ const mockChatState = {
   state: { messages: [], status: { loading: false } },
 };
 
+jest.mock("next/router", () => ({
+  useRouter: (): any => ({ pathname: "/research/studies" }),
+}));
+
 jest.mock("@databiosphere/findable-ui/lib/hooks/useConfig", () => ({
   useConfig: (): any => ({
     config: { ai: { url: "https://test-api/search" } },

--- a/app/views/ResearchView/artifact/form.tsx
+++ b/app/views/ResearchView/artifact/form.tsx
@@ -4,6 +4,7 @@ import { useChatDispatch } from "@databiosphere/findable-ui/lib/views/ResearchVi
 import { useChatState } from "@databiosphere/findable-ui/lib/views/ResearchView/state/hooks/UseChatState/hook";
 import { QueryContext } from "@databiosphere/findable-ui/lib/views/ResearchView/state/query/context";
 import { MessageResponse } from "@databiosphere/findable-ui/lib/views/ResearchView/state/types";
+import { useRouter } from "next/router";
 import {
   createContext,
   FormEvent,
@@ -121,14 +122,17 @@ export function MultiTurnQueryProvider({
   const sessionIdRef = useRef<string>("");
   const abortRef = useRef<AbortController | null>(null);
 
-  // After the first assistant response, switch the input placeholder to refine
-  // mode. Idempotent — only writes when it isn't already set — so it re-applies
-  // to a fresh textarea after navigation (the provider is app-wide) without
-  // rewriting on every message.
+  // After the first assistant response, switch the research prompt's placeholder
+  // to refine mode. This provider is app-wide, and the home hero uses the same
+  // `ai-prompt` input name, so gate on the research route to avoid touching it.
+  // Re-runs on route change too (idempotent placeholder check), so it re-applies
+  // to the textarea when the research view remounts on a later visit.
+  const { pathname } = useRouter();
   const { state } = useChatState();
   const messages = state.messages;
   const lastMessage = messages[messages.length - 1];
   useEffect(() => {
+    if (!pathname.startsWith("/research")) return;
     if (!lastMessage || !isAssistantMessage(lastMessage)) return;
     const input = document.querySelector<HTMLTextAreaElement>(
       'textarea[name="ai-prompt"]'
@@ -137,7 +141,7 @@ export function MultiTurnQueryProvider({
     if (input && input.placeholder !== refine) {
       input.placeholder = refine;
     }
-  }, [lastMessage]);
+  }, [lastMessage, pathname]);
 
   /**
    * Submits a query to the agent search API under the current session.

--- a/app/views/ResearchView/artifact/form.tsx
+++ b/app/views/ResearchView/artifact/form.tsx
@@ -116,8 +116,8 @@ export function MultiTurnQueryProvider({
   const submitUrl = getSearchApiUrl(config.ai?.url);
   const dispatch = useChatDispatch();
   // Conversation id created lazily on first submission so the backend can key
-  // multi-turn state. The agent handles resets server-side, so one id per
-  // provider lifetime (one research-view visit) is sufficient.
+  // multi-turn state. This provider is mounted app-wide (in _app), so one id per
+  // app session is sufficient; the agent handles new-topic resets server-side.
   const sessionIdRef = useRef<string>("");
   const abortRef = useRef<AbortController | null>(null);
   const placeholderSetRef = useRef(false);

--- a/app/views/ResearchView/artifact/form.tsx
+++ b/app/views/ResearchView/artifact/form.tsx
@@ -120,24 +120,22 @@ export function MultiTurnQueryProvider({
   // app session is sufficient; the agent handles new-topic resets server-side.
   const sessionIdRef = useRef<string>("");
   const abortRef = useRef<AbortController | null>(null);
-  const placeholderSetRef = useRef(false);
 
   // After the first assistant response, switch the input placeholder to refine
-  // mode. Guarded so the DOM query/write happens once per visit, not on every
-  // message; the guard is set only once the write succeeds, so it still retries
-  // if the input isn't mounted yet on the first assistant message.
+  // mode. Idempotent — only writes when it isn't already set — so it re-applies
+  // to a fresh textarea after navigation (the provider is app-wide) without
+  // rewriting on every message.
   const { state } = useChatState();
   const messages = state.messages;
   const lastMessage = messages[messages.length - 1];
   useEffect(() => {
-    if (placeholderSetRef.current) return;
     if (!lastMessage || !isAssistantMessage(lastMessage)) return;
     const input = document.querySelector<HTMLTextAreaElement>(
       'textarea[name="ai-prompt"]'
     );
-    if (input) {
-      input.placeholder = "Refine, e.g. “also where BMI was measured”";
-      placeholderSetRef.current = true;
+    const refine = "Refine, e.g. “also where BMI was measured”";
+    if (input && input.placeholder !== refine) {
+      input.placeholder = refine;
     }
   }, [lastMessage]);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -33,6 +33,7 @@ import TagManager from "react-gtm-module";
 import { Footer } from "../app/components/Layout/components/Footer/footer";
 import { useEntities } from "../app/services/workflows/hooks/UseEntities/hook";
 import { getSearchApiUrl } from "../app/utils/searchApiUrl";
+import { MultiTurnQueryProvider } from "../app/views/ResearchView/artifact/form";
 import { BREAKPOINTS } from "../site-config/common/constants";
 
 const FEATURE_FLAGS = Object.values(FEATURES);
@@ -117,33 +118,37 @@ function MyApp(props: AppPropsWithComponent): JSX.Element {
                       <StyledHeader {...header} transparent={homePage} />
                     </ThemeProvider>
                     <ChatProvider initialArgs={ai?.prompt} url={aiUrl}>
-                      <ExploreStateProvider entityListType={entityListType}>
-                        <DataDictionaryStateProvider>
-                          <FileManifestStateProvider>
-                            <Main>
-                              <ErrorBoundary
-                                fallbackRender={({
-                                  error,
-                                  reset,
-                                }: {
-                                  error: DataExplorerError;
-                                  reset: () => void;
-                                }): JSX.Element => (
-                                  <DXError
-                                    errorMessage={error.message}
-                                    requestUrlMessage={error.requestUrlMessage}
-                                    rootPath={redirectRootToPath}
-                                    onReset={reset}
-                                  />
-                                )}
-                              >
-                                <Component {...pageProps} />
-                                <Floating {...floating} />
-                              </ErrorBoundary>
-                            </Main>
-                          </FileManifestStateProvider>
-                        </DataDictionaryStateProvider>
-                      </ExploreStateProvider>
+                      <MultiTurnQueryProvider>
+                        <ExploreStateProvider entityListType={entityListType}>
+                          <DataDictionaryStateProvider>
+                            <FileManifestStateProvider>
+                              <Main>
+                                <ErrorBoundary
+                                  fallbackRender={({
+                                    error,
+                                    reset,
+                                  }: {
+                                    error: DataExplorerError;
+                                    reset: () => void;
+                                  }): JSX.Element => (
+                                    <DXError
+                                      errorMessage={error.message}
+                                      requestUrlMessage={
+                                        error.requestUrlMessage
+                                      }
+                                      rootPath={redirectRootToPath}
+                                      onReset={reset}
+                                    />
+                                  )}
+                                >
+                                  <Component {...pageProps} />
+                                  <Floating {...floating} />
+                                </ErrorBoundary>
+                              </Main>
+                            </FileManifestStateProvider>
+                          </DataDictionaryStateProvider>
+                        </ExploreStateProvider>
+                      </MultiTurnQueryProvider>
                     </ChatProvider>
                     <Footer />
                   </AppLayout>

--- a/pages/research/[researchType]/index.tsx
+++ b/pages/research/[researchType]/index.tsx
@@ -3,7 +3,6 @@ import { GetStaticPaths, GetStaticProps } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 import { Artifact } from "../../../app/views/ResearchView/artifact/artifact";
-import { MultiTurnQueryProvider } from "../../../app/views/ResearchView/artifact/form";
 import {
   RESEARCH_TYPE,
   ResearchType,
@@ -39,11 +38,9 @@ export const getStaticProps: GetStaticProps<Props, Params> = async ({
 
 const Page = ({ researchType }: Props): JSX.Element => {
   return (
-    <MultiTurnQueryProvider>
-      <ResearchView>
-        <Artifact researchType={researchType} />
-      </ResearchView>
-    </MultiTurnQueryProvider>
+    <ResearchView>
+      <Artifact researchType={researchType} />
+    </ResearchView>
   );
 };
 


### PR DESCRIPTION
Closes #415. **Prod bugfix** — the home hero search returns 422.

## Root cause
`_app.tsx` wraps the app in findable-ui's `ChatProvider`, whose default `QueryProvider` posts `{ query }` (no `sessionId`). `MultiTurnQueryProvider` (which adds `sessionId`) was mounted **only on research pages**, so the home hero search used the default provider → `{ query }` → the renamed agent `/search` (#412) rejects it (`session_id` required) → **422**.

## Fix
Hoist `MultiTurnQueryProvider` into `_app.tsx` (inside `ChatProvider`, wrapping the app content) and remove the per-research-page mount. Now every `useQuery()` entry point uses the `sessionId`-aware `onSubmit`; the global `ChatProvider` state + provider `sessionId` ref persist across the home→research navigation.

## Verification
- check-format / eslint / `next typegen && tsc` clean; **140 jest tests pass** (provider unit tests unchanged)
- Frontend-only; deploy to prod fixes the home 422. Independent of #414.

Refs #410, #412.