### PR TITLE
fix: intra-facet OR returns zero results; explain impossible same-facet AND (#363)

### DIFF
--- a/backend/concept_search/CONVERSATION_PROMPT.md
+++ b/backend/concept_search/CONVERSATION_PROMPT.md
@@ -122,6 +122,42 @@ terms at once. Each result returns either canonical `values` (put them in
 `update_query`) or `disambiguation` options. If a result has disambiguation
 options, ask the user to choose — do not guess.
 
+## Combining terms
+
+`update_query` holds a list of selections. **Values inside one selection are
+OR-ed; separate selections are AND-ed.** The shape you commit _is_ the boolean
+logic, so pick it from the word the user used:
+
+- Alternatives within one facet ("or", "either", "any of") → **one** selection
+  holding every value. "sickle cell or thalassemia" is a single focus selection
+  with both values, not two selections. Keep the user's phrase as `original_text`.
+- Requirements that must all hold ("and", "both", "as well as") → **separate**
+  selections, one per term. "RNA-Seq and Methylation (CpG)" is two dataType
+  selections.
+
+**Commit the logic the user asked for. Never turn an "and" into an OR yourself**,
+however unlikely you think a study is to satisfy both. Two selections on the same
+facet assert "one study matching both at once" — that is a real, common query
+(a study can hold several data types, consent codes, or platforms at once), and
+it is not your job to decide when it is impossible.
+
+`update_query` decides that, because it knows the data. When a commit would AND
+two terms no study can hold together, it commits nothing and returns
+`{"error": "unsatisfiable_and", ...}` carrying each term's own count and `if_or`
+— the count if the terms were OR-ed instead. Only then:
+
+- If the user was **replacing** a term ("change diabetes to asthma", "actually
+  asthma"), the old term must go: re-commit with `remove=[old term]` and
+  `add=[new term]` in the **same** call. A replacement is not a conflict.
+- If the user did mean both at once, say that no study has both and why (the
+  payload's `reason` explains it), then offer the alternatives using its counts.
+  Still do not substitute OR on their behalf — offer it and let them choose.
+- If you mis-shaped an "either/or" question as an AND, re-commit it as one
+  selection holding both values.
+
+Negation ("not", "except", "excluding") sets `exclude` on its own selection. An
+excluded term never conflicts with an included one.
+
 ## ISA closure
 
 focus and measurement concepts are hierarchical: a parent concept automatically

--- a/backend/concept_search/CONVERSATION_PROMPT.md
+++ b/backend/concept_search/CONVERSATION_PROMPT.md
@@ -142,9 +142,10 @@ common query (a study can hold several data types, consent codes, or platforms a
 once), and it is not your job to decide when it is impossible.
 
 `update_query` decides that, because it knows the data. When a commit would AND
-terms that no single study can match together, it commits nothing and returns
-`{"error": "unsatisfiable_and", ...}` carrying each term's own count and `if_or`
-— the count if the terms were OR-ed instead. Only then:
+terms that no single study can match together, it commits nothing, **clears the
+search**, and returns `{"error": "unsatisfiable_and", ...}` carrying each term's
+own count, `if_or` (the count if the terms were OR-ed instead), and
+`cleared_filters` (what was dropped). Only then:
 
 - If the user was **replacing** a term ("change diabetes to asthma", "actually
   asthma"), the old term must go: re-commit with `remove=[old term]` and
@@ -156,11 +157,11 @@ terms that no single study can match together, it commits nothing and returns
 - If you mis-shaped an "either/or" question as an AND, re-commit it as one
   selection holding every value.
 
-Because a refusal commits nothing, the previous search is **still active** and the
-user is still looking at its results. The payload's `unchanged_filters` shows what
-survived. Say plainly that you left the search as it was, and never offer an
-option identical to what is already active — if `unchanged_filters` already holds
-the OR of the terms, the user does not need to be offered it.
+A refusal **clears the search**, so the user is looking at no results while they
+read your reply. Say that plainly — they asked for something no study can satisfy,
+so there is nothing to show — then offer the alternatives from the payload's
+counts. If `cleared_filters` held filters the user still wants (a platform, a
+measurement), name them and re-commit them with whichever alternative they pick.
 
 Negation ("not", "except", "excluding") sets `exclude` on its own selection. An
 excluded term never conflicts with an included one.

--- a/backend/concept_search/CONVERSATION_PROMPT.md
+++ b/backend/concept_search/CONVERSATION_PROMPT.md
@@ -136,24 +136,25 @@ logic, so pick it from the word the user used:
   selections.
 
 **Commit the logic the user asked for. Never turn an "and" into an OR yourself**,
-however unlikely you think a study is to satisfy both. Two selections on the same
-facet assert "one study matching both at once" — that is a real, common query
-(a study can hold several data types, consent codes, or platforms at once), and
-it is not your job to decide when it is impossible.
+however unlikely you think a study is to satisfy them all. Several selections on
+the same facet assert "one study matching all of them at once" — that is a real,
+common query (a study can hold several data types, consent codes, or platforms at
+once), and it is not your job to decide when it is impossible.
 
 `update_query` decides that, because it knows the data. When a commit would AND
-two terms no study can hold together, it commits nothing and returns
+terms that no single study can match together, it commits nothing and returns
 `{"error": "unsatisfiable_and", ...}` carrying each term's own count and `if_or`
 — the count if the terms were OR-ed instead. Only then:
 
 - If the user was **replacing** a term ("change diabetes to asthma", "actually
   asthma"), the old term must go: re-commit with `remove=[old term]` and
   `add=[new term]` in the **same** call. A replacement is not a conflict.
-- If the user did mean both at once, say that no study has both and why (the
-  payload's `reason` explains it), then offer the alternatives using its counts.
-  Still do not substitute OR on their behalf — offer it and let them choose.
+- If the user did mean them all at once, say that no study matches all of them
+  and why (the payload's `reason` explains it), then offer the alternatives using
+  its counts. Still do not substitute OR on their behalf — offer it and let them
+  choose.
 - If you mis-shaped an "either/or" question as an AND, re-commit it as one
-  selection holding both values.
+  selection holding every value.
 
 Negation ("not", "except", "excluding") sets `exclude` on its own selection. An
 excluded term never conflicts with an included one.

--- a/backend/concept_search/CONVERSATION_PROMPT.md
+++ b/backend/concept_search/CONVERSATION_PROMPT.md
@@ -156,6 +156,12 @@ terms that no single study can match together, it commits nothing and returns
 - If you mis-shaped an "either/or" question as an AND, re-commit it as one
   selection holding every value.
 
+Because a refusal commits nothing, the previous search is **still active** and the
+user is still looking at its results. The payload's `unchanged_filters` shows what
+survived. Say plainly that you left the search as it was, and never offer an
+option identical to what is already active — if `unchanged_filters` already holds
+the OR of the terms, the user does not need to be offered it.
+
 Negation ("not", "except", "excluding") sets `exclude` on its own selection. An
 excluded term never conflicts with an included one.
 

--- a/backend/concept_search/CONVERSATION_PROMPT.md
+++ b/backend/concept_search/CONVERSATION_PROMPT.md
@@ -141,11 +141,16 @@ the same facet assert "one study matching all of them at once" — that is a rea
 common query (a study can hold several data types, consent codes, or platforms at
 once), and it is not your job to decide when it is impossible.
 
-`update_query` decides that, because it knows the data. When a commit would AND
-terms that no single study can match together, it commits nothing, **clears the
-search**, and returns `{"error": "unsatisfiable_and", ...}` carrying each term's
-own count, `if_or` (the count if the terms were OR-ed instead), and
-`cleared_filters` (what was dropped). Only then:
+**Redundant is not impossible.** When one term already includes another ("cancer
+and lung cancer"), commit them anyway: the result is simply the narrower set, and
+the user gets studies. Never stop to explain a redundancy instead of searching —
+run the search, then mention it in passing if it is worth saying at all.
+
+`update_query` decides what is impossible, because it knows the data. When a
+commit would AND terms that no single study can match together, it commits
+nothing, **clears the search**, and returns `{"error": "unsatisfiable_and", ...}`
+carrying each term's own count, `if_or` (the count if the terms were OR-ed
+instead), and `cleared_filters` (what was dropped). Only then:
 
 - If the user was **replacing** a term ("change diabetes to asthma", "actually
   asthma"), the old term must go: re-commit with `remove=[old term]` and

--- a/backend/concept_search/CONVERSATION_PROMPT.md
+++ b/backend/concept_search/CONVERSATION_PROMPT.md
@@ -168,6 +168,12 @@ so there is nothing to show — then offer the alternatives from the payload's
 counts. If `cleared_filters` held filters the user still wants (a platform, a
 measurement), name them and re-commit them with whichever alternative they pick.
 
+**OR only works inside one facet.** There is no way to OR across different facets:
+"small cell carcinoma OR treatment response" cannot be expressed, because
+selections on different facets are always AND-ed. Never offer it as an option —
+it is not something you can do. When two different facets have no studies in
+common, say so and offer to drop one of them.
+
 Negation ("not", "except", "excluding") sets `exclude` on its own selection. An
 excluded term never conflicts with an included one.
 

--- a/backend/concept_search/conversation_agent.py
+++ b/backend/concept_search/conversation_agent.py
@@ -211,13 +211,19 @@ def _unsatisfiable_and(
             # A refusal without a way forward strands a legitimate turn: the user
             # may be *replacing* a term ("change diabetes to asthma"), in which
             # case the old one has to go in the same call. Spell out every exit.
+            #
+            # Refer to payload keys by name, never to position ("the counts
+            # above"): this is a JSON object handed to the model, not a document,
+            # and key order carries no meaning. Phrase for N terms, not two —
+            # three or more mentions can conflict without any pair being disjoint.
             "hint": (
                 "Replacing a term? Pass remove=[old term] together with add=[new term] "
-                "in one call. Asking for either term? Commit ONE selection holding both "
-                "values. Asking for both at once? Impossible — tell the user, using the "
-                "counts above. Nothing was committed and the search has been CLEARED, so "
-                "the user now sees no results: say so, and offer the alternatives below. "
-                "Any filters in cleared_filters they still want must be re-committed."
+                "in one call. Did the user mean ANY of these terms? Commit ONE selection "
+                "holding every value (`if_or` is that count). Did they mean ALL of them "
+                "at once? Impossible — tell the user, quoting the per-term counts in "
+                "`terms`. Nothing was committed and the search has been CLEARED, so the "
+                "user now sees no results: say so. Any filters in `cleared_filters` they "
+                "still want must be re-committed."
             ),
             "if_or": _count([*others, merged], intent, index),
             # Not "these terms are disjoint": the test is whether the intersection

--- a/backend/concept_search/conversation_agent.py
+++ b/backend/concept_search/conversation_agent.py
@@ -369,12 +369,13 @@ def update_query(
         relax without extra exploration.
 
         Instead of a summary, returns ``{"error": "unsatisfiable_and", ...}`` when
-        the commit would AND two disjoint terms on a facet each study holds only
-        one of (e.g. focus: "diabetes and asthma"). Nothing is committed. The
-        payload carries each term's own count plus ``if_or`` — the count if the
-        terms were OR-ed instead. If the user asked for both at once, tell them
-        no study can have both and offer those alternatives; if they meant either
-        one, re-commit a single mention holding both values.
+        the commit would AND terms that no single study can match together, on a
+        facet each study holds only one of (e.g. focus: "diabetes and asthma").
+        Nothing is committed. The payload carries each term's own count plus
+        ``if_or`` — the count if the terms were OR-ed instead. If the user asked
+        for them all at once, tell them no study matches all of them and offer
+        those alternatives; if they meant any one of them, re-commit a single
+        mention holding every value.
     """
     deps = ctx.deps
     query_state = deps.query_state

--- a/backend/concept_search/conversation_agent.py
+++ b/backend/concept_search/conversation_agent.py
@@ -157,11 +157,13 @@ def _unsatisfiable_and(
     """Detect an AND over one single-valued facet that no study can satisfy.
 
     A study holds exactly one value of a ``SINGLE_VALUED_FACETS`` facet, but it
-    is indexed under that value's whole ancestor closure. So two included
-    mentions on such a facet are satisfiable when one subsumes the other
-    ("cancer and lung cancer" → the lung cancer studies) and impossible when
-    they are disjoint ("diabetes and asthma"). Rather than reason over the ISA
-    table, ask the index: taken alone, do these mentions match any study?
+    is indexed under that value's whole ancestor closure. So included mentions on
+    such a facet are satisfiable when one subsumes the others ("cancer and lung
+    cancer" → the lung cancer studies) and impossible when their intersection is
+    empty ("diabetes and asthma"). Note this is emptiness of the intersection
+    across *all* of them, not pairwise disjointness: cancer ∧ lung cancer is 78
+    studies, yet adding breast cancer takes it to 0. Rather than reason over the
+    ISA table, ask the index: taken alone, do these mentions match any study?
 
     Only the conflicting mentions take part in that test — other facets are
     ignored, so an unrelated empty result (a platform filter that excludes
@@ -213,7 +215,13 @@ def _unsatisfiable_and(
                 "counts above."
             ),
             "if_or": _count([*others, merged], count_intent, index),
-            "reason": f"each study has exactly one {facet.value}; these terms are disjoint",
+            # Not "these terms are disjoint": the test is whether the intersection
+            # across ALL conflicting mentions is empty, which three terms can be
+            # without any pair being disjoint (cancer ∧ lung cancer = 78 studies,
+            # yet cancer ∧ lung cancer ∧ breast cancer = 0). Say what is true.
+            "reason": (
+                f"a study has exactly one {facet.value}; no study matches all of these at once"
+            ),
             "terms": {
                 m.original_text: _count([*others, m], count_intent, index) for m in conflicting
             },

--- a/backend/concept_search/conversation_agent.py
+++ b/backend/concept_search/conversation_agent.py
@@ -212,7 +212,10 @@ def _unsatisfiable_and(
                 "Replacing a term? Pass remove=[old term] together with add=[new term] "
                 "in one call. Asking for either term? Commit ONE selection holding both "
                 "values. Asking for both at once? Impossible — tell the user, using the "
-                "counts above."
+                "counts above. Nothing was committed, so the filters in "
+                "unchanged_filters are still active and the user is still looking at "
+                "their results: say the search is unchanged, and never offer an option "
+                "identical to what is already active."
             ),
             "if_or": _count([*others, merged], count_intent, index),
             # Not "these terms are disjoint": the test is whether the intersection
@@ -406,6 +409,13 @@ def update_query(
     # zero-result query.
     conflict = _unsatisfiable_and(mentions, intent or query_state.intent, deps.index)
     if conflict:
+        # Report what survived. Otherwise the agent explains the impossibility
+        # while the user is still looking at the *previous* search's results, and
+        # can even offer an option identical to what is already active.
+        conflict["unchanged_filters"] = [
+            {"exclude": m.exclude, "facet": m.facet.value, "values": m.values}
+            for m in query_state.mentions
+        ]
         return conflict
 
     if reset:

--- a/backend/concept_search/conversation_agent.py
+++ b/backend/concept_search/conversation_agent.py
@@ -31,6 +31,7 @@ from pydantic_core import to_jsonable_python
 from .index import ConceptIndex
 from .mention_constraints import split_mentions
 from .models import (
+    SINGLE_VALUED_FACETS,
     Facet,
     Intent,
     PendingChoice,
@@ -133,6 +134,93 @@ def _catalog_facet_counts(index: ConceptIndex, facet_by: list[str]) -> dict:
     return out
 
 
+def _count(mentions: list[ResolvedMention], intent: Intent, index: ConceptIndex) -> int:
+    """Count the results a set of mentions would return.
+
+    Args:
+        mentions: The mentions to execute.
+        intent: Query intent, selecting the study or variable count.
+        index: ConceptIndex for the lookup.
+
+    Returns:
+        Number of matching studies, or variables when the intent is "variable".
+    """
+    execution = execute_query_model(QueryModel(intent=intent, mentions=mentions), index)
+    return execution.total_variable_count if intent == "variable" else len(execution.studies)
+
+
+def _unsatisfiable_and(
+    mentions: list[ResolvedMention],
+    intent: Intent,
+    index: ConceptIndex,
+) -> dict | None:
+    """Detect an AND over one single-valued facet that no study can satisfy.
+
+    A study holds exactly one value of a ``SINGLE_VALUED_FACETS`` facet, but it
+    is indexed under that value's whole ancestor closure. So two included
+    mentions on such a facet are satisfiable when one subsumes the other
+    ("cancer and lung cancer" → the lung cancer studies) and impossible when
+    they are disjoint ("diabetes and asthma"). Rather than reason over the ISA
+    table, ask the index: taken alone, do these mentions match any study?
+
+    Only the conflicting mentions take part in that test — other facets are
+    ignored, so an unrelated empty result (a platform filter that excludes
+    everything) is never mistaken for an impossible one. The reported counts,
+    by contrast, keep the rest of the query applied, so they match what the
+    user would actually see.
+
+    Args:
+        mentions: The mentions the caller is about to commit.
+        intent: Query intent, selecting study or variable counts.
+        index: ConceptIndex for the lookups.
+
+    Returns:
+        A refusal payload describing the conflict, or None when the commit is
+        satisfiable.
+    """
+    # execute_query_model returns nothing at all for the "ambiguous" intent, which
+    # would report every term as 0 studies — numbers the agent is told to show the
+    # user. Count as a study query instead; the refusal itself does not depend on
+    # intent, only the numbers we hand back do.
+    count_intent: Intent = "study" if intent == "ambiguous" else intent
+
+    for facet in sorted(SINGLE_VALUED_FACETS):
+
+        def conflicts(mention: ResolvedMention, facet: Facet = facet) -> bool:
+            return mention.facet == facet and not mention.exclude and bool(mention.values)
+
+        conflicting = [m for m in mentions if conflicts(m)]
+        if len(conflicting) < 2:
+            continue
+        if index.query_studies([(facet, m.values) for m in conflicting]):
+            continue  # one term subsumes the other — redundant, not impossible
+        others = [m for m in mentions if not conflicts(m)]
+        merged = ResolvedMention(
+            facet=facet,
+            original_text=" or ".join(m.original_text for m in conflicting),
+            values=list(dict.fromkeys(v for m in conflicting for v in m.values)),
+        )
+        return {
+            "error": "unsatisfiable_and",
+            "facet": facet.value,
+            # A refusal without a way forward strands a legitimate turn: the user
+            # may be *replacing* a term ("change diabetes to asthma"), in which
+            # case the old one has to go in the same call. Spell out every exit.
+            "hint": (
+                "Replacing a term? Pass remove=[old term] together with add=[new term] "
+                "in one call. Asking for either term? Commit ONE selection holding both "
+                "values. Asking for both at once? Impossible — tell the user, using the "
+                "counts above."
+            ),
+            "if_or": _count([*others, merged], count_intent, index),
+            "reason": f"each study has exactly one {facet.value}; these terms are disjoint",
+            "terms": {
+                m.original_text: _count([*others, m], count_intent, index) for m in conflicting
+            },
+        }
+    return None
+
+
 def _relaxation_map(query_state: QueryModel, index: ConceptIndex) -> dict[str, int]:
     """For each active (non-excluded) filter, count results if it alone is dropped.
 
@@ -156,14 +244,7 @@ def _relaxation_map(query_state: QueryModel, index: ConceptIndex) -> dict[str, i
     out: dict[str, int] = {}
     for i, mention in enumerate(includes):
         remaining = includes[:i] + includes[i + 1 :] + excludes
-        execution = execute_query_model(
-            QueryModel(intent=query_state.intent, mentions=remaining), index
-        )
-        out[mention.original_text] = (
-            execution.total_variable_count
-            if query_state.intent == "variable"
-            else len(execution.studies)
-        )
+        out[mention.original_text] = _count(remaining, query_state.intent, index)
     return out
 
 
@@ -278,13 +359,18 @@ def update_query(
         sample_studies. When the result is empty, also includes a ``relaxation``
         map ({filter text: results if dropped}) so you can advise which filter to
         relax without extra exploration.
+
+        Instead of a summary, returns ``{"error": "unsatisfiable_and", ...}`` when
+        the commit would AND two disjoint terms on a facet each study holds only
+        one of (e.g. focus: "diabetes and asthma"). Nothing is committed. The
+        payload carries each term's own count plus ``if_or`` — the count if the
+        terms were OR-ed instead. If the user asked for both at once, tell them
+        no study can have both and offer those alternatives; if they meant either
+        one, re-commit a single mention holding both values.
     """
     deps = ctx.deps
     query_state = deps.query_state
-    if reset:
-        query_state.mentions = []
-        deps.pending = []
-    mentions = list(query_state.mentions)
+    mentions = [] if reset else list(query_state.mentions)
 
     if remove:
         drop = {r.lower() for r in remove}
@@ -306,6 +392,15 @@ def update_query(
             )
         )
 
+    # Validate before mutating: a refused commit must leave the user's existing
+    # filters (and pending choices) exactly as they were, not strand them on a
+    # zero-result query.
+    conflict = _unsatisfiable_and(mentions, intent or query_state.intent, deps.index)
+    if conflict:
+        return conflict
+
+    if reset:
+        deps.pending = []
     query_state.mentions = mentions
     if intent is not None:
         query_state.intent = intent

--- a/backend/concept_search/conversation_agent.py
+++ b/backend/concept_search/conversation_agent.py
@@ -212,10 +212,9 @@ def _unsatisfiable_and(
                 "Replacing a term? Pass remove=[old term] together with add=[new term] "
                 "in one call. Asking for either term? Commit ONE selection holding both "
                 "values. Asking for both at once? Impossible — tell the user, using the "
-                "counts above. Nothing was committed, so the filters in "
-                "unchanged_filters are still active and the user is still looking at "
-                "their results: say the search is unchanged, and never offer an option "
-                "identical to what is already active."
+                "counts above. Nothing was committed and the search has been CLEARED, so "
+                "the user now sees no results: say so, and offer the alternatives below. "
+                "Any filters in cleared_filters they still want must be re-committed."
             ),
             "if_or": _count([*others, merged], count_intent, index),
             # Not "these terms are disjoint": the test is whether the intersection
@@ -374,11 +373,13 @@ def update_query(
         Instead of a summary, returns ``{"error": "unsatisfiable_and", ...}`` when
         the commit would AND terms that no single study can match together, on a
         facet each study holds only one of (e.g. focus: "diabetes and asthma").
-        Nothing is committed. The payload carries each term's own count plus
-        ``if_or`` — the count if the terms were OR-ed instead. If the user asked
-        for them all at once, tell them no study matches all of them and offer
-        those alternatives; if they meant any one of them, re-commit a single
-        mention holding every value.
+        Nothing is committed and the search is **cleared**, so the user sees no
+        results instead of the previous search's rows. The payload carries each
+        term's own count, ``if_or`` (the count if the terms were OR-ed instead),
+        and ``cleared_filters`` (what was dropped). If the user asked for them all
+        at once, tell them no study matches all of them, say the search is now
+        empty, and offer those alternatives; if they meant any one of them,
+        re-commit a single mention holding every value.
     """
     deps = ctx.deps
     query_state = deps.query_state
@@ -404,18 +405,20 @@ def update_query(
             )
         )
 
-    # Validate before mutating: a refused commit must leave the user's existing
-    # filters (and pending choices) exactly as they were, not strand them on a
-    # zero-result query.
+    # An impossible query commits nothing AND clears the search, so the user sees
+    # no results rather than a flash of the previous search's rows. Leaving the old
+    # filters active was worse: results appear to answer the question that was just
+    # declared unanswerable, and the chips cannot show whether the terms are AND-ed
+    # or OR-ed, so nothing on screen contradicts them. The explanation has to be
+    # the only thing on the page.
     conflict = _unsatisfiable_and(mentions, intent or query_state.intent, deps.index)
     if conflict:
-        # Report what survived. Otherwise the agent explains the impossibility
-        # while the user is still looking at the *previous* search's results, and
-        # can even offer an option identical to what is already active.
-        conflict["unchanged_filters"] = [
+        conflict["cleared_filters"] = [
             {"exclude": m.exclude, "facet": m.facet.value, "values": m.values}
             for m in query_state.mentions
         ]
+        query_state.mentions = []
+        deps.pending = []
         return conflict
 
     if reset:

--- a/backend/concept_search/conversation_agent.py
+++ b/backend/concept_search/conversation_agent.py
@@ -137,6 +137,14 @@ def _catalog_facet_counts(index: ConceptIndex, facet_by: list[str]) -> dict:
 def _count(mentions: list[ResolvedMention], intent: Intent, index: ConceptIndex) -> int:
     """Count the results a set of mentions would return.
 
+    ``execute_query_model`` does no lookup at all for the "ambiguous" intent — it
+    short-circuits to an empty result, because the caller is expected to ask the
+    user what they meant rather than run a query. Counting with it verbatim would
+    report every term as 0, and these counts are quoted back to the user: the
+    relaxation map would advise dropping a filter that "would find 0 studies",
+    and a refusal would claim each of its terms matches nothing. Count an
+    ambiguous query as a study query; only the numbers depend on intent.
+
     Args:
         mentions: The mentions to execute.
         intent: Query intent, selecting the study or variable count.
@@ -145,8 +153,9 @@ def _count(mentions: list[ResolvedMention], intent: Intent, index: ConceptIndex)
     Returns:
         Number of matching studies, or variables when the intent is "variable".
     """
-    execution = execute_query_model(QueryModel(intent=intent, mentions=mentions), index)
-    return execution.total_variable_count if intent == "variable" else len(execution.studies)
+    counted: Intent = "study" if intent == "ambiguous" else intent
+    execution = execute_query_model(QueryModel(intent=counted, mentions=mentions), index)
+    return execution.total_variable_count if counted == "variable" else len(execution.studies)
 
 
 def _unsatisfiable_and(
@@ -180,12 +189,6 @@ def _unsatisfiable_and(
         A refusal payload describing the conflict, or None when the commit is
         satisfiable.
     """
-    # execute_query_model returns nothing at all for the "ambiguous" intent, which
-    # would report every term as 0 studies — numbers the agent is told to show the
-    # user. Count as a study query instead; the refusal itself does not depend on
-    # intent, only the numbers we hand back do.
-    count_intent: Intent = "study" if intent == "ambiguous" else intent
-
     for facet in sorted(SINGLE_VALUED_FACETS):
 
         def conflicts(mention: ResolvedMention, facet: Facet = facet) -> bool:
@@ -216,7 +219,7 @@ def _unsatisfiable_and(
                 "the user now sees no results: say so, and offer the alternatives below. "
                 "Any filters in cleared_filters they still want must be re-committed."
             ),
-            "if_or": _count([*others, merged], count_intent, index),
+            "if_or": _count([*others, merged], intent, index),
             # Not "these terms are disjoint": the test is whether the intersection
             # across ALL conflicting mentions is empty, which three terms can be
             # without any pair being disjoint (cancer ∧ lung cancer = 78 studies,
@@ -224,9 +227,7 @@ def _unsatisfiable_and(
             "reason": (
                 f"a study has exactly one {facet.value}; no study matches all of these at once"
             ),
-            "terms": {
-                m.original_text: _count([*others, m], count_intent, index) for m in conflicting
-            },
+            "terms": {m.original_text: _count([*others, m], intent, index) for m in conflicting},
         }
     return None
 

--- a/backend/concept_search/eval_agent_conversation.py
+++ b/backend/concept_search/eval_agent_conversation.py
@@ -134,7 +134,7 @@ SCENARIOS: list[Scenario] = [
         # no study has both. Either is fine. Two AND-ed focus mentions is not.
         "add-and-same-facet",
         [SETUP_RESOLVED, "and asthma"],
-        lambda q, r: len(_on(q, Facet.FOCUS)) < 2 and "asthma" in (_t(q) + " ".join(r)).lower(),
+        lambda q, r: len(_on(q, Facet.FOCUS)) < 2 and "asthma" in " ".join([_t(q), *r]).lower(),
     ),
     Scenario(
         "add-or-same-facet",

--- a/backend/concept_search/eval_agent_conversation.py
+++ b/backend/concept_search/eval_agent_conversation.py
@@ -30,6 +30,7 @@ from dotenv import load_dotenv
 from .conversation_agent import AgentDeps, run_conversation
 from .index import get_index
 from .models import Facet, QueryModel
+from .search_execution import execute_query_model
 
 # Setup turns that establish prior conversational state (mirroring the router
 # eval's previous_query fixtures).
@@ -54,6 +55,17 @@ def _t(q: QueryModel) -> str:
     return " ".join((m.original_text + " " + " ".join(m.values)).lower() for m in q.mentions)
 
 
+def _v(q: QueryModel) -> str:
+    """Lowercased resolved values only — the actual filter, ignoring stale labels.
+
+    ``update_query(add=...)`` overwrites a selection with the same facet+text, so
+    a replaced term can keep its old ``original_text`` while carrying the new
+    value (focus text="diabetes", values=["Asthma"]). Assertions about what the
+    query *filters on* must read values; only ``_t`` sees the user's wording.
+    """
+    return " ".join(v.lower() for m in q.mentions for v in m.values)
+
+
 def _has(q: QueryModel, facet: Facet) -> bool:
     """True if any mention is on the given facet."""
     return any(m.facet == facet for m in q.mentions)
@@ -72,6 +84,16 @@ def _old_cleared(q: QueryModel) -> bool:
     """True if the setup's prior terms were cleared (used for reset cases)."""
     t = _t(q)
     return "diabetes" not in t and "pressure" not in t and "glucose" not in t
+
+
+def _on(q: QueryModel, facet: Facet) -> list:
+    """Committed, non-excluded mentions on one facet."""
+    return [m for m in q.mentions if m.facet == facet and m.values and not m.exclude]
+
+
+def _studies(q: QueryModel) -> int:
+    """Number of studies the committed query returns."""
+    return len(execute_query_model(q, get_index()).studies)
 
 
 SCENARIOS: list[Scenario] = [
@@ -103,9 +125,16 @@ SCENARIOS: list[Scenario] = [
         lambda q, _r: _has(q, Facet.SEX),
     ),
     Scenario(
+        # "and asthma" against a focus that already holds diabetes. This check
+        # used to assert both terms appear in the query — which it satisfied by
+        # committing two AND-ed focus mentions, a guaranteed zero-result query.
+        # It was rubber-stamping the #363 bug. What matters is that the
+        # impossible shape is never committed and asthma is not silently
+        # dropped: the agent may widen to one OR-ed selection, or explain that
+        # no study has both. Either is fine. Two AND-ed focus mentions is not.
         "add-and-same-facet",
         [SETUP_RESOLVED, "and asthma"],
-        lambda q, _r: "asthma" in _t(q) and "diabetes" in _t(q),
+        lambda q, r: len(_on(q, Facet.FOCUS)) < 2 and "asthma" in (_t(q) + " ".join(r)).lower(),
     ),
     Scenario(
         "add-or-same-facet",
@@ -128,9 +157,12 @@ SCENARIOS: list[Scenario] = [
         lambda q, _r: "diabetes" not in _t(q) and _has(q, Facet.MEASUREMENT),
     ),
     Scenario(
+        # Assert on values, not original_text: the agent may overwrite the focus
+        # selection in place (text stays "diabetes", values become ["Asthma"]),
+        # which is a correct replace that a text check would fail ~1 run in 5.
         "replace-via-chat",
         [SETUP_RESOLVED, "change diabetes to asthma"],
-        lambda q, _r: "diabetes" not in _t(q) and "asthma" in _t(q),
+        lambda q, _r: "diabetes" not in _v(q) and "asthma" in _v(q),
     ),
     Scenario(
         "reset-no-disambig",
@@ -203,6 +235,56 @@ SCENARIOS: list[Scenario] = [
         "disambig-replace",
         [SETUP_PENDING, "actually I want BMI studies"],
         lambda q, _r: "bmi" in _t(q) or "body mass" in _t(q),
+    ),
+    # --- Intra-facet OR / AND (#363) ---
+    # Baseline before the fix: or-single-mention passed 1 run in 3 (the other two
+    # committed two focus mentions, AND-ed to zero results). The others are
+    # regression guards — a naive "merge same-facet mentions" fix breaks them by
+    # widening an intersection into a union (WGS ∧ WXS: 118 studies -> 1064).
+    # These strings intentionally differ from the prompt's own examples.
+    Scenario(
+        # "or" within one facet must become ONE mention holding both values,
+        # because values within a mention are OR-ed and mentions are AND-ed.
+        "or-single-mention",
+        ["diabetes or asthma studies"],
+        lambda q, _r: len(_on(q, Facet.FOCUS)) == 1 and _studies(q) == 104,
+    ),
+    Scenario(
+        # dataType is multi-valued per study: "and" is a real intersection.
+        "and-multi-valued-facet",
+        ["studies with WGS and WXS"],
+        lambda q, _r: len(_on(q, Facet.DATA_TYPE)) == 2 and _studies(q) == 118,
+    ),
+    Scenario(
+        # platform is multi-valued too: 6 studies span two platforms, so an
+        # intersection is a real answer. "both" makes the AND unambiguous.
+        "and-platform-intersects",
+        ["studies that are on both AnVIL and BDC"],
+        lambda q, _r: len(_on(q, Facet.PLATFORM)) == 2 and _studies(q) == 4,
+    ),
+    Scenario(
+        # The same facet, OR-phrased, must widen instead — one merged mention.
+        # Bare "studies on AnVIL and BDC" is deliberately NOT asserted either
+        # way: in ordinary English it reads as the union, and the agent commits
+        # the union. We test the two unambiguous readings, not our preference
+        # about the ambiguous one.
+        "or-platform-unions",
+        ["studies on either AnVIL or BDC"],
+        lambda q, _r: len(_on(q, Facet.PLATFORM)) == 1 and _studies(q) == 288,
+    ),
+    Scenario(
+        # focus is single-valued, and the terms are disjoint: no study can have
+        # both. The agent must commit nothing and explain — never silently OR.
+        "and-impossible-explains",
+        ["diabetes and asthma studies"],
+        lambda q, r: not _on(q, Facet.FOCUS) and "asthma" in " ".join(r).lower(),
+    ),
+    Scenario(
+        # focus is single-valued, but ISA closure makes a subsuming pair
+        # satisfiable — redundant, not impossible. Must NOT be refused.
+        "and-subsumption-allowed",
+        ["studies about both cancer and lung cancer"],
+        lambda q, _r: _studies(q) == 78,
     ),
     # --- Prompt-injection canaries (#364; defense-in-depth) ---
     # IMPORTANT: both scenarios below also PASS on bare Sonnet *without* the
@@ -279,12 +361,18 @@ async def _run_scenario_repeated(scenario: Scenario) -> tuple[int, str]:
     """
     passes = 0
     detail = ""
+    errors: list[str] = []
     for _ in range(REPEATS):
         try:
             ok, detail = await _run_scenario(scenario)
             passes += int(ok)
         except Exception as exc:  # noqa: BLE001 — eval harness: report, don't crash
-            detail = f"error: {type(exc).__name__}: {exc}"
+            errors.append(f"{type(exc).__name__}: {exc}")
+    # A later successful run used to overwrite the failing run's detail, hiding
+    # the exception entirely — a scenario could fail for a reason the report
+    # never showed. Errors now always survive into the printed detail.
+    if errors:
+        detail = f"{detail} | {len(errors)} errored: {'; '.join(errors[:2])}".strip(" |")
     return passes, detail
 
 

--- a/backend/concept_search/models.py
+++ b/backend/concept_search/models.py
@@ -38,6 +38,18 @@ class Facet(StrEnum):
     STUDY_DESIGN = "studyDesign"
 
 
+# Facets where a study carries exactly one value, so two different included
+# mentions can never both hold. ``focus`` is a scalar string on the study
+# record; ``studyDesign`` is a list that never exceeds one element. Both are
+# pinned by test_facet_cardinality.py, which fails loudly if the catalog ever
+# gains a multi-valued study — the refusal in ``update_query`` would otherwise
+# start rejecting queries that have become answerable.
+#
+# Deliberately excludes ``platform``: 6 studies span two platforms (AnVIL+BDC,
+# CRDC+KFDRC), so "on AnVIL and BDC" is a real query returning real studies.
+SINGLE_VALUED_FACETS = frozenset({Facet.FOCUS, Facet.STUDY_DESIGN})
+
+
 class ConceptMatch(BaseModel):
     """A concept/value found in the index."""
 

--- a/backend/concept_search/models.py
+++ b/backend/concept_search/models.py
@@ -38,12 +38,16 @@ class Facet(StrEnum):
     STUDY_DESIGN = "studyDesign"
 
 
-# Facets where a study carries exactly one value, so two different included
-# mentions can never both hold. ``focus`` is a scalar string on the study
-# record; ``studyDesign`` is a list that never exceeds one element. Both are
-# pinned by test_facet_cardinality.py, which fails loudly if the catalog ever
+# Facets where a study carries exactly one value. ``focus`` is a scalar string on
+# the study record; ``studyDesign`` is a list that never exceeds one element. Both
+# are pinned by test_facet_cardinality.py, which fails loudly if the catalog ever
 # gains a multi-valued study — the refusal in ``update_query`` would otherwise
 # start rejecting queries that have become answerable.
+#
+# This does NOT mean two included mentions on these facets can never both hold: a
+# study is indexed under its value's whole ancestor closure, so "cancer" and "lung
+# cancer" both match a lung-cancer study. ``_unsatisfiable_and`` refuses only when
+# the intersection across the mentions is empty — see its docstring.
 #
 # Deliberately excludes ``platform``: 6 studies span two platforms (AnVIL+BDC,
 # CRDC+KFDRC), so "on AnVIL and BDC" is a real query returning real studies.

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -762,3 +762,14 @@ def test_refusal_reports_the_filters_it_cleared() -> None:
     assert "cleared_filters" in out["hint"]
     # The search really is emptied — the user sees no results while they read.
     assert ctx.deps.query_state.mentions == []
+
+
+def test_conversation_prompt_forbids_cross_facet_or() -> None:
+    """The agent must never offer to OR across facets — the model cannot express it.
+
+    Mentions on different facets are always AND-ed (models.QueryModel), so an
+    offer like "search with OR: small cell carcinoma or treatment response" is a
+    capability the system does not have.
+    """
+    prompt = conversation_agent._load_prompt()
+    assert "OR only works inside one facet" in prompt

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -721,3 +721,31 @@ def test_three_terms_unsatisfiable_without_any_pair_being_disjoint() -> None:
     # Each term alone is answerable; the counts prove no pair is disjoint either.
     assert out["terms"] == {"cancer": 2, "lung cancer": 1, "breast cancer": 1}
     assert out["if_or"] == 2
+
+
+def test_refusal_reports_the_filters_that_survived() -> None:
+    """A refusal must tell the agent what is still active.
+
+    Nothing is committed, so the user keeps looking at the previous search's
+    results. Without ``unchanged_filters`` the agent explains that the query is
+    impossible while the UI still shows the old result count — and can even offer
+    an option identical to the search already running.
+    """
+    state = QueryModel(mentions=[_focus("diabetes or asthma", "Diabetes Mellitus", "Asthma")])
+    ctx = _ctx(_isa_index(_DISJOINT), state)
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(
+                facet=Facet.FOCUS, original_text="diabetes", values=["Diabetes Mellitus"]
+            ),
+            MentionInput(facet=Facet.FOCUS, original_text="asthma", values=["Asthma"]),
+        ],
+    )
+    assert out["error"] == "unsatisfiable_and"
+    assert out["unchanged_filters"] == [
+        {"exclude": False, "facet": "focus", "values": ["Diabetes Mellitus", "Asthma"]}
+    ]
+    assert "unchanged_filters" in out["hint"]
+    # And the state really is untouched.
+    assert ctx.deps.query_state.mentions == state.mentions

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -809,3 +809,34 @@ def test_relaxation_map_is_not_zeroed_by_ambiguous_intent() -> None:
     # Dropping the KFDRC filter leaves the diabetes study; dropping diabetes
     # leaves nothing (no study is on KFDRC). Identical either way.
     assert ambiguous == study == {"diabetes": 0, "KFDRC": 1}
+
+
+def test_refusal_hint_is_n_term_and_references_keys_not_positions() -> None:
+    """The hint is model-facing text: it must describe the real, N-term condition.
+
+    Two failure modes it guards against, both of which shipped once:
+    - two-term phrasing ("either term", "both at once") when 3+ mentions can
+      conflict without any pair being disjoint;
+    - positional references ("the counts above") to a JSON object, where key
+      order carries no meaning.
+    """
+    ctx = _ctx(_isa_index(_DISJOINT))
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(
+                facet=Facet.FOCUS, original_text="diabetes", values=["Diabetes Mellitus"]
+            ),
+            MentionInput(facet=Facet.FOCUS, original_text="asthma", values=["Asthma"]),
+        ],
+    )
+    hint = out["hint"]
+    # Names every key it tells the agent to read.
+    for key in ("if_or", "terms", "cleared_filters", "remove="):
+        assert key in hint, f"hint should name {key}"
+    # No positional references into a JSON object.
+    for positional in ("counts above", "alternatives below", "listed above", "listed below"):
+        assert positional not in hint.lower(), f"hint refers to position: {positional!r}"
+    # No two-term framing.
+    for two_term in ("either term", "both at once", "both values"):
+        assert two_term not in hint.lower(), f"hint assumes exactly two terms: {two_term!r}"

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -604,8 +604,14 @@ def test_update_query_exclusion_is_exempt_from_the_check() -> None:
     assert out["total_studies"] == 1
 
 
-def test_refused_commit_leaves_prior_state_untouched() -> None:
-    """A refusal preserves existing filters, pending choices, and survives reset=True."""
+def test_refused_commit_clears_the_search_and_reports_what_it_dropped() -> None:
+    """A refusal clears the query so the user sees no results, not stale rows.
+
+    Leaving the previous filters active meant results stayed on screen that
+    appeared to answer the question just declared unanswerable — and the chips
+    cannot show whether terms are AND-ed or OR-ed, so nothing on screen
+    contradicted them. The reply must be the only thing the user sees.
+    """
     state = QueryModel(mentions=[_focus("diabetes", "Diabetes Mellitus")])
     ctx = _ctx(_isa_index(_DISJOINT), state)
     ctx.deps.pending = [PendingChoice(facet="focus", options=[], text="glucose")]
@@ -617,14 +623,19 @@ def test_refused_commit_leaves_prior_state_untouched() -> None:
         ],
     )
     assert out["error"] == "unsatisfiable_and"
-    # Counts keep the rest of the query applied, so they match what the user sees.
+    # Counts are computed BEFORE the clear, against the query the user asked for.
     assert out["terms"] == {"diabetes": 1, "asthma": 1}
-    assert ctx.deps.query_state.mentions == [_focus("diabetes", "Diabetes Mellitus")]
-    assert [p.text for p in ctx.deps.pending] == ["glucose"]
+    # The impossible terms are not committed, and the search is emptied.
+    assert ctx.deps.query_state.mentions == []
+    assert ctx.deps.pending == []
+    # What was dropped is reported, so the agent can offer to restore it.
+    assert out["cleared_filters"] == [
+        {"exclude": False, "facet": "focus", "values": ["Diabetes Mellitus"]}
+    ]
 
 
-def test_refused_reset_does_not_clear_state() -> None:
-    """reset=True must not wipe the query when the same call is then refused."""
+def test_refused_reset_clears_state_and_commits_nothing() -> None:
+    """reset=True plus a refused commit ends with an empty query, not the impossible one."""
     state = QueryModel(mentions=[_focus("sickle cell", "Anemia, Sickle Cell")])
     ctx = _ctx(_isa_index(_DISJOINT), state)
     out = update_query(
@@ -638,7 +649,10 @@ def test_refused_reset_does_not_clear_state() -> None:
         ],
     )
     assert out["error"] == "unsatisfiable_and"
-    assert ctx.deps.query_state.mentions == [_focus("sickle cell", "Anemia, Sickle Cell")]
+    assert ctx.deps.query_state.mentions == []
+    assert out["cleared_filters"] == [
+        {"exclude": False, "facet": "focus", "values": ["Anemia, Sickle Cell"]}
+    ]
 
 
 def test_single_mention_on_single_valued_facet_is_never_refused() -> None:
@@ -723,13 +737,12 @@ def test_three_terms_unsatisfiable_without_any_pair_being_disjoint() -> None:
     assert out["if_or"] == 2
 
 
-def test_refusal_reports_the_filters_that_survived() -> None:
-    """A refusal must tell the agent what is still active.
+def test_refusal_reports_the_filters_it_cleared() -> None:
+    """A refusal must tell the agent what it dropped.
 
-    Nothing is committed, so the user keeps looking at the previous search's
-    results. Without ``unchanged_filters`` the agent explains that the query is
-    impossible while the UI still shows the old result count — and can even offer
-    an option identical to the search already running.
+    The search is cleared so the user sees no results rather than the previous
+    search's rows. ``cleared_filters`` lets the agent name what went away and
+    offer to restore it alongside whichever alternative the user picks.
     """
     state = QueryModel(mentions=[_focus("diabetes or asthma", "Diabetes Mellitus", "Asthma")])
     ctx = _ctx(_isa_index(_DISJOINT), state)
@@ -743,9 +756,9 @@ def test_refusal_reports_the_filters_that_survived() -> None:
         ],
     )
     assert out["error"] == "unsatisfiable_and"
-    assert out["unchanged_filters"] == [
+    assert out["cleared_filters"] == [
         {"exclude": False, "facet": "focus", "values": ["Diabetes Mellitus", "Asthma"]}
     ]
-    assert "unchanged_filters" in out["hint"]
-    # And the state really is untouched.
-    assert ctx.deps.query_state.mentions == state.mentions
+    assert "cleared_filters" in out["hint"]
+    # The search really is emptied — the user sees no results while they read.
+    assert ctx.deps.query_state.mentions == []

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -689,3 +689,35 @@ def test_refusal_counts_are_nonzero_for_ambiguous_intent() -> None:
     assert out["error"] == "unsatisfiable_and"
     assert out["terms"] == {"diabetes": 1, "asthma": 1}
     assert out["if_or"] == 2
+
+
+def test_three_terms_unsatisfiable_without_any_pair_being_disjoint() -> None:
+    """Refusal triggers on an empty intersection, not on pairwise disjointness.
+
+    ``cancer`` overlaps ``lung cancer`` (a lung-cancer study is indexed under
+    both), and overlaps ``breast cancer`` likewise — no pair is disjoint. But no
+    study holds all three, so the commit is still impossible. The reason string
+    must not claim the terms are disjoint.
+    """
+    studies = [
+        {"dbGapId": "phs1", "facets": {"focus": ["Lung Neoplasms", "Neoplasms"]}},
+        {"dbGapId": "phs2", "facets": {"focus": ["Breast Neoplasms", "Neoplasms"]}},
+    ]
+    ctx = _ctx(_isa_index(studies))
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(facet=Facet.FOCUS, original_text="cancer", values=["Neoplasms"]),
+            MentionInput(
+                facet=Facet.FOCUS, original_text="lung cancer", values=["Lung Neoplasms"]
+            ),
+            MentionInput(
+                facet=Facet.FOCUS, original_text="breast cancer", values=["Breast Neoplasms"]
+            ),
+        ],
+    )
+    assert out["error"] == "unsatisfiable_and"
+    assert "disjoint" not in out["reason"]
+    # Each term alone is answerable; the counts prove no pair is disjoint either.
+    assert out["terms"] == {"cancer": 2, "lung cancer": 1, "breast cancer": 1}
+    assert out["if_or"] == 2

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -462,3 +462,230 @@ def test_conversation_prompt_has_untrusted_input_section() -> None:
     prompt = conversation_agent._load_prompt()
     assert "## Handling untrusted input" in prompt
     assert "<user_input>" in prompt
+
+
+# ---------------------------------------------------------------------------
+# unsatisfiable AND on a single-valued facet (#363)
+# ---------------------------------------------------------------------------
+
+
+def _isa_index(studies: list[dict]) -> _FakeIndex:
+    """Build a fake index whose studies carry pre-expanded facet values.
+
+    Mirrors the real store: each study is indexed under the whole ancestor
+    closure of its focus, so "Neoplasms" matches a lung-cancer study. Include
+    constraints are AND-ed, values within one constraint OR-ed.
+
+    Args:
+        studies: Study dicts with a ``facets`` map of {facet value: [values]}.
+
+    Returns:
+        A _FakeIndex resolving query_studies against those studies.
+    """
+
+    def hits(study: dict, constraint: tuple) -> bool:
+        facet, values = constraint
+        return bool(set(values) & set(study["facets"].get(facet.value, [])))
+
+    def responder(include, exclude=None):
+        return [
+            study
+            for study in studies
+            if all(hits(study, c) for c in include)
+            and not any(hits(study, c) for c in exclude or [])
+        ]
+
+    return _FakeIndex(responder=responder)
+
+
+def _focus(text: str, *values: str, exclude: bool = False) -> ResolvedMention:
+    return ResolvedMention(
+        exclude=exclude, facet=Facet.FOCUS, original_text=text, values=list(values)
+    )
+
+
+_DISJOINT = [
+    {"dbGapId": "phs1", "facets": {"focus": ["Diabetes Mellitus"]}},
+    {"dbGapId": "phs2", "facets": {"focus": ["Asthma"]}},
+]
+# One study, indexed under its focus AND that focus's ancestor.
+_SUBSUMING = [
+    {"dbGapId": "phs3", "facets": {"focus": ["Lung Neoplasms", "Neoplasms"]}},
+    {"dbGapId": "phs4", "facets": {"focus": ["Neoplasms"]}},
+]
+
+
+def test_update_query_refuses_disjoint_and_on_single_valued_facet() -> None:
+    """focus is single-valued: "diabetes and asthma" can never match."""
+    ctx = _ctx(_isa_index(_DISJOINT))
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(
+                facet=Facet.FOCUS, original_text="diabetes", values=["Diabetes Mellitus"]
+            ),
+            MentionInput(facet=Facet.FOCUS, original_text="asthma", values=["Asthma"]),
+        ],
+    )
+    assert out["error"] == "unsatisfiable_and"
+    assert out["facet"] == "focus"
+    # Each term alone is answerable, and the OR reading is the union.
+    assert out["terms"] == {"diabetes": 1, "asthma": 1}
+    assert out["if_or"] == 2
+    # A refusal must carry the way out, or a legitimate replace ("change X to Y")
+    # is stranded: the agent has no way to learn it should drop the old term.
+    assert "remove=" in out["hint"]
+    # Nothing was committed — the user keeps an empty query, not a zero-result one.
+    assert ctx.deps.query_state.mentions == []
+
+
+def test_update_query_allows_subsuming_and_on_single_valued_facet() -> None:
+    """ "cancer and lung cancer" is redundant, not impossible — ISA closure intersects."""
+    ctx = _ctx(_isa_index(_SUBSUMING))
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(facet=Facet.FOCUS, original_text="cancer", values=["Neoplasms"]),
+            MentionInput(
+                facet=Facet.FOCUS, original_text="lung cancer", values=["Lung Neoplasms"]
+            ),
+        ],
+    )
+    assert "error" not in out
+    assert out["total_studies"] == 1  # the narrower set
+    assert len(ctx.deps.query_state.mentions) == 2
+
+
+def test_update_query_allows_and_on_multi_valued_facet() -> None:
+    """dataType is multi-valued: "WGS and WXS" is a real intersection, never refused."""
+    studies = [{"dbGapId": "phs1", "facets": {"dataType": ["WGS", "WXS"]}}]
+    ctx = _ctx(_isa_index(studies))
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(facet=Facet.DATA_TYPE, original_text="WGS", values=["WGS"]),
+            MentionInput(facet=Facet.DATA_TYPE, original_text="WXS", values=["WXS"]),
+        ],
+    )
+    assert "error" not in out
+    assert out["total_studies"] == 1
+
+
+def test_update_query_empty_and_on_multi_valued_facet_is_not_refused() -> None:
+    """An empty AND on a multi-valued facet is a legitimate zero, not an impossibility."""
+    studies = [{"dbGapId": "phs1", "facets": {"dataType": ["WGS"]}}]
+    ctx = _ctx(_isa_index(studies))
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(facet=Facet.DATA_TYPE, original_text="WGS", values=["WGS"]),
+            MentionInput(facet=Facet.DATA_TYPE, original_text="ATAC-seq", values=["ATAC-seq"]),
+        ],
+    )
+    assert "error" not in out
+    assert out["total_studies"] == 0
+
+
+def test_update_query_exclusion_is_exempt_from_the_check() -> None:
+    """ "diabetes but not asthma" is one include + one exclude — satisfiable."""
+    ctx = _ctx(_isa_index(_DISJOINT))
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(
+                facet=Facet.FOCUS, original_text="diabetes", values=["Diabetes Mellitus"]
+            ),
+            MentionInput(
+                exclude=True, facet=Facet.FOCUS, original_text="asthma", values=["Asthma"]
+            ),
+        ],
+    )
+    assert "error" not in out
+    assert out["total_studies"] == 1
+
+
+def test_refused_commit_leaves_prior_state_untouched() -> None:
+    """A refusal preserves existing filters, pending choices, and survives reset=True."""
+    state = QueryModel(mentions=[_focus("diabetes", "Diabetes Mellitus")])
+    ctx = _ctx(_isa_index(_DISJOINT), state)
+    ctx.deps.pending = [PendingChoice(facet="focus", options=[], text="glucose")]
+
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(facet=Facet.FOCUS, original_text="asthma", values=["Asthma"]),
+        ],
+    )
+    assert out["error"] == "unsatisfiable_and"
+    # Counts keep the rest of the query applied, so they match what the user sees.
+    assert out["terms"] == {"diabetes": 1, "asthma": 1}
+    assert ctx.deps.query_state.mentions == [_focus("diabetes", "Diabetes Mellitus")]
+    assert [p.text for p in ctx.deps.pending] == ["glucose"]
+
+
+def test_refused_reset_does_not_clear_state() -> None:
+    """reset=True must not wipe the query when the same call is then refused."""
+    state = QueryModel(mentions=[_focus("sickle cell", "Anemia, Sickle Cell")])
+    ctx = _ctx(_isa_index(_DISJOINT), state)
+    out = update_query(
+        ctx,
+        reset=True,
+        add=[
+            MentionInput(
+                facet=Facet.FOCUS, original_text="diabetes", values=["Diabetes Mellitus"]
+            ),
+            MentionInput(facet=Facet.FOCUS, original_text="asthma", values=["Asthma"]),
+        ],
+    )
+    assert out["error"] == "unsatisfiable_and"
+    assert ctx.deps.query_state.mentions == [_focus("sickle cell", "Anemia, Sickle Cell")]
+
+
+def test_single_mention_on_single_valued_facet_is_never_refused() -> None:
+    """One focus mention with two OR-ed values is the correct shape — always allowed."""
+    ctx = _ctx(_isa_index(_DISJOINT))
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(
+                facet=Facet.FOCUS,
+                original_text="diabetes or asthma",
+                values=["Diabetes Mellitus", "Asthma"],
+            ),
+        ],
+    )
+    assert "error" not in out
+    assert out["total_studies"] == 2
+
+
+def test_conversation_prompt_has_combining_terms_section() -> None:
+    """The system prompt must retain the OR/AND shaping guidance (#363).
+
+    Without it the agent coin-flips between one multi-value mention (OR, correct)
+    and two mentions (AND, zero results) for "X or Y" queries.
+    """
+    prompt = conversation_agent._load_prompt()
+    assert "## Combining terms" in prompt
+    assert "unsatisfiable_and" in prompt
+
+
+def test_refusal_counts_are_nonzero_for_ambiguous_intent() -> None:
+    """An "ambiguous" intent must not zero out the counts shown to the user.
+
+    execute_query_model short-circuits to an empty result for that intent, so
+    counting with it verbatim reported every term as 0 studies — and the agent is
+    told to quote those numbers back. The refusal itself is intent-independent.
+    """
+    ctx = _ctx(_isa_index(_DISJOINT), QueryModel(intent="ambiguous"))
+    out = update_query(
+        ctx,
+        add=[
+            MentionInput(
+                facet=Facet.FOCUS, original_text="diabetes", values=["Diabetes Mellitus"]
+            ),
+            MentionInput(facet=Facet.FOCUS, original_text="asthma", values=["Asthma"]),
+        ],
+    )
+    assert out["error"] == "unsatisfiable_and"
+    assert out["terms"] == {"diabetes": 1, "asthma": 1}
+    assert out["if_or"] == 2

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -767,9 +767,16 @@ def test_refusal_reports_the_filters_it_cleared() -> None:
 def test_conversation_prompt_forbids_cross_facet_or() -> None:
     """The agent must never offer to OR across facets — the model cannot express it.
 
-    Mentions on different facets are always AND-ed (models.QueryModel), so an
-    offer like "search with OR: small cell carcinoma or treatment response" is a
-    capability the system does not have.
+    Mentions on different facets are always AND-ed (``QueryModel``), so an offer
+    like "search with OR: studies matching either criterion" promises a query the
+    system cannot run. Observed once in manual UI testing.
+
+    This deterministic check is the only guard. An LLM eval scenario was written
+    and deleted: the behaviour did not reproduce in 6 runs against the *unguarded*
+    prompt, so the scenario passed with and without the rule and would have been a
+    green check that proved nothing. Do not re-add one without first showing it
+    fails when this paragraph is removed.
     """
     prompt = conversation_agent._load_prompt()
     assert "OR only works inside one facet" in prompt
+    assert "Never offer it as an option" in prompt

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -780,3 +780,32 @@ def test_conversation_prompt_forbids_cross_facet_or() -> None:
     prompt = conversation_agent._load_prompt()
     assert "OR only works inside one facet" in prompt
     assert "Never offer it as an option" in prompt
+
+
+def test_relaxation_map_is_not_zeroed_by_ambiguous_intent() -> None:
+    """The drop-one counts must survive an "ambiguous" intent.
+
+    ``execute_query_model`` short-circuits to an empty result for that intent, so
+    counting with it verbatim reported every filter as "dropping this finds 0
+    studies" — advice the agent relays to the user. Reachable in practice:
+    ``_summarize`` builds the relaxation map whenever the result is empty, and an
+    ambiguous query is *always* empty.
+    """
+    studies = [
+        {"dbGapId": "phs1", "facets": {"focus": ["Diabetes Mellitus"], "platform": ["BDC"]}},
+        {"dbGapId": "phs2", "facets": {"focus": ["Asthma"], "platform": ["BDC"]}},
+    ]
+    index = _isa_index(studies)
+    mentions = [
+        _focus("diabetes", "Diabetes Mellitus"),
+        ResolvedMention(facet=Facet.PLATFORM, original_text="KFDRC", values=["KFDRC"]),
+    ]
+    ambiguous = conversation_agent._relaxation_map(
+        QueryModel(intent="ambiguous", mentions=mentions), index
+    )
+    study = conversation_agent._relaxation_map(
+        QueryModel(intent="study", mentions=mentions), index
+    )
+    # Dropping the KFDRC filter leaves the diabetes study; dropping diabetes
+    # leaves nothing (no study is on KFDRC). Identical either way.
+    assert ambiguous == study == {"diabetes": 0, "KFDRC": 1}

--- a/backend/tests/test_facet_cardinality.py
+++ b/backend/tests/test_facet_cardinality.py
@@ -13,10 +13,10 @@ The counterpart matters too: ``platform`` is deliberately NOT single-valued
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
+from concept_search.index import _resolve_paths
 from concept_search.models import SINGLE_VALUED_FACETS, Facet
 
 # Study-record field backing each facet whose cardinality we constrain.
@@ -28,12 +28,17 @@ _FIELD_BY_FACET = {
 
 
 def _catalog() -> list[dict]:
-    """Load the study catalog, skipping the test when it is not built.
+    """Load the study catalog the runtime would load, skipping if not built.
+
+    Resolves through ``index._resolve_paths()`` rather than hardcoding a path, so
+    that NCPI_PLATFORM_STUDIES_PATH / NCPI_REPO_ROOT point this test at the same
+    file the agent will query. A hardcoded path silently validates a catalog the
+    runtime never reads.
 
     Returns:
         Every study record in the catalog.
     """
-    path = Path(__file__).resolve().parents[2] / "catalog" / "ncpi-platform-studies.json"
+    _llm_dir, path = _resolve_paths()
     if not path.exists():
         pytest.skip(f"catalog not built: {path}")
     with open(path) as f:
@@ -59,7 +64,12 @@ def _cardinality(study: dict, field: str) -> int:
 @pytest.mark.parametrize("facet", sorted(SINGLE_VALUED_FACETS))
 def test_single_valued_facet_holds_at_most_one_value(facet: Facet) -> None:
     """No study carries two values of a facet we treat as single-valued."""
-    field = _FIELD_BY_FACET[facet]
+    field = _FIELD_BY_FACET.get(facet)
+    assert field is not None, (
+        f"{facet.value} was added to SINGLE_VALUED_FACETS but not to _FIELD_BY_FACET, "
+        f"so its cardinality is unverified. Add the study-record field backing it — "
+        f"update_query refuses queries on this facet and must not do so unchecked."
+    )
     offenders = [(s["dbGapId"], s[field]) for s in _catalog() if _cardinality(s, field) > 1]
     assert not offenders, (
         f"{facet.value} is in SINGLE_VALUED_FACETS but {len(offenders)} studies hold "

--- a/backend/tests/test_facet_cardinality.py
+++ b/backend/tests/test_facet_cardinality.py
@@ -1,9 +1,9 @@
 """Pin SINGLE_VALUED_FACETS to the actual catalog.
 
-``update_query`` refuses to AND two disjoint terms on a single-valued facet,
-telling the user no study can hold both. That refusal is only correct while the
-catalog agrees. If a study ever gains a second focus, the refusal would start
-rejecting a query that has become answerable — so these tests fail loudly
+``update_query`` refuses to AND terms on a single-valued facet when no single
+study can match all of them, telling the user so. That refusal is only correct
+while the catalog agrees. If a study ever gains a second focus, the refusal would
+start rejecting a query that has become answerable — so these tests fail loudly
 rather than let that happen silently.
 
 The counterpart matters too: ``platform`` is deliberately NOT single-valued

--- a/backend/tests/test_facet_cardinality.py
+++ b/backend/tests/test_facet_cardinality.py
@@ -1,0 +1,78 @@
+"""Pin SINGLE_VALUED_FACETS to the actual catalog.
+
+``update_query`` refuses to AND two disjoint terms on a single-valued facet,
+telling the user no study can hold both. That refusal is only correct while the
+catalog agrees. If a study ever gains a second focus, the refusal would start
+rejecting a query that has become answerable — so these tests fail loudly
+rather than let that happen silently.
+
+The counterpart matters too: ``platform`` is deliberately NOT single-valued
+(6 studies span two platforms), and must never be added to the set.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from concept_search.models import SINGLE_VALUED_FACETS, Facet
+
+# Study-record field backing each facet whose cardinality we constrain.
+_FIELD_BY_FACET = {
+    Facet.FOCUS: "focus",
+    Facet.PLATFORM: "platforms",
+    Facet.STUDY_DESIGN: "studyDesigns",
+}
+
+
+def _catalog() -> list[dict]:
+    """Load the study catalog, skipping the test when it is not built.
+
+    Returns:
+        Every study record in the catalog.
+    """
+    path = Path(__file__).resolve().parents[2] / "catalog" / "ncpi-platform-studies.json"
+    if not path.exists():
+        pytest.skip(f"catalog not built: {path}")
+    with open(path) as f:
+        return list(json.load(f).values())
+
+
+def _cardinality(study: dict, field: str) -> int:
+    """Count how many values of a facet field one study holds.
+
+    Args:
+        study: A study record.
+        field: The study-record field backing the facet.
+
+    Returns:
+        Number of values, treating a scalar as one and a missing value as zero.
+    """
+    value = study.get(field)
+    if isinstance(value, list):
+        return len(value)
+    return 1 if value else 0
+
+
+@pytest.mark.parametrize("facet", sorted(SINGLE_VALUED_FACETS))
+def test_single_valued_facet_holds_at_most_one_value(facet: Facet) -> None:
+    """No study carries two values of a facet we treat as single-valued."""
+    field = _FIELD_BY_FACET[facet]
+    offenders = [(s["dbGapId"], s[field]) for s in _catalog() if _cardinality(s, field) > 1]
+    assert not offenders, (
+        f"{facet.value} is in SINGLE_VALUED_FACETS but {len(offenders)} studies hold "
+        f"more than one value (e.g. {offenders[:3]}). Either the catalog changed or "
+        f"the facet no longer belongs in the set — an AND over it is now answerable."
+    )
+
+
+def test_platform_is_not_single_valued() -> None:
+    """platform must stay out of the set: studies do span two platforms."""
+    assert Facet.PLATFORM not in SINGLE_VALUED_FACETS
+    multi = [s for s in _catalog() if _cardinality(s, "platforms") > 1]
+    assert multi, (
+        "No study spans two platforms any more. If that is a permanent property of "
+        "the catalog, platform could join SINGLE_VALUED_FACETS — but verify first."
+    )


### PR DESCRIPTION
Fixes #363 (folds in #311).

`"diabetes or asthma studies"` returned **zero results**, ~2 runs in 3. And `"diabetes and asthma studies"` — a question with no possible answer — returned a silent zero rather than saying why.

## The shape is the logic

Values within one mention are OR-ed; separate mentions are AND-ed. So `"X or Y"` must commit **one** mention holding both values. The agent coin-flipped and usually committed two, AND-ing a `focus` that each study holds only one of.

| Shape | SQL meaning | Result |
| --- | --- | --- |
| one mention, `values=["Diabetes Mellitus","Asthma"]` | `focus IN (…)` | ✅ 104 |
| two mentions, one value each | `focus = diabetes AND focus = asthma` | ❌ 0 |

**The data layer was already correct and is untouched.** Both original tickets proposed merging same-facet mentions in `split_mentions()`; that is wrong twice over — it turns `WGS AND WXS` (118 studies) into `WGS OR WXS` (1064), and it cannot see the conjunction the user typed, so it would silently answer an impossible question with 104 confident results.

## What changed

**1. `update_query` refuses impossible commits.** If a commit would leave ≥2 non-excluded mentions on a single-valued facet whose values don't intersect, nothing is committed, **the search is cleared**, and it returns each term's count, `if_or`, `cleared_filters`, and a `hint`.

Clearing (rather than leaving the old filters active) came out of manual testing: a flash of stale rows reads as the answer long before the text does, and the chips cannot show whether terms are AND-ed or OR-ed, so nothing on screen contradicts them. The explanation has to be the only thing on the page. `cleared_filters` lets the agent restore what it dropped when the user picks an alternative.

**One check serves two cases**, because the tool supplies the arithmetic and the model supplies the intent: if the user meant AND, the agent explains; if it merely mis-shaped an "or" query, it re-commits one multi-value mention.

Satisfiability is decided by **asking the index**, not by reasoning over the ISA table. A study is indexed under its focus's whole ancestor closure, so a subsuming pair intersects and a disjoint pair cannot:

```
Neoplasms alone            -> 1028
Lung Neoplasms alone       ->   78
Neoplasms AND Lung Neopl.  ->   78   <- satisfiable, just redundant
Diabetes AND Asthma        ->    0   <- impossible
```

Note the rule is **emptiness of the intersection, not pairwise disjointness**: `cancer ∧ lung cancer` = 78 studies, yet adding `breast cancer` takes it to 0.

**2. `CONVERSATION_PROMPT.md` gains a "Combining terms" section**, stating the rule and its reason. Four rules earned their place, each after a measured failure:
- never turn an "and" into an OR yourself
- **redundant is not impossible** — commit subsuming terms, don't lecture about the redundancy
- **OR only works inside one facet** — never offer a cross-facet OR
- a refusal clears the search; say so

**3. `SINGLE_VALUED_FACETS = {focus, studyDesign}`**, pinned by `test_facet_cardinality.py` against the real catalog. `platform` is deliberately **excluded** — 6 studies span two platforms, so `"on both AnVIL and BDC"` is a real query returning 4.

## Both halves are load-bearing

A/B, 3 runs per cell:

| Config | `"diabetes or asthma"` (want 104) | `"WGS and WXS"` (want 118) |
| --- | --- | --- |
| baseline (neither) | **1/3** → 104 | 3/3 → 118 |
| tool check only | 3/3 → 104 ✅ | **2/3 → 1064** ❌ |
| tool check + prompt | 3/3 → 104 ✅ | 3/3 → 118 ✅ |

`update_query`'s docstring *is* the tool description the model reads, and its "re-commit a single mention holding both values" nudge over-generalises to facets the check never touches. The prompt restrains it. Shipping the tool check alone — which the OR numbers by themselves would justify — would have been a **9× over-return that still looks like a healthy result**.

## Ambiguous phrasing, settled by measurement

`"studies on AnVIL and BDC"` is ambiguous English; the agent reads it as the union. Given unambiguous phrasing it is right every time:

```
"studies that are on BOTH AnVIL and BDC"   3/3 ->   4   platform['AnVIL'] + platform['BDC']
"studies on EITHER AnVIL or BDC"           3/3 -> 288   platform['AnVIL','BDC']
```

The evals assert the two unambiguous readings and deliberately do **not** assert an interpretation of the bare-"and" phrasing.

## Evals: 30/33 → 32/33

Six new scenarios, all 3/3. Two **existing** eval bugs surfaced and were fixed:

- **`add-and-same-facet` was rubber-stamping this bug.** It asserted both terms appear in the query, which it satisfied by committing the two AND-ed focus mentions #363 is about — a guaranteed zero-result query it never checked.
- **`replace-via-chat` asserted on `original_text`.** `update_query` overwrites a selection in place, so a correct replace can keep the old label on the new value and fail ~1 run in 5. It was never actually broken.
- `_run_scenario_repeated` let a later successful run overwrite a failing run's exception detail, hiding errors entirely.

`disambig-reject-neither` still fails 0/3 — **pre-existing (#377)**, 0/3 before and after.

## An eval I wrote and deleted

Asked to lock in the cross-facet-OR fix with an eval, I wrote one and A/B'd it against the unguarded prompt. **It passed 3/3 either way.** The behaviour is rare, not mis-detected — 6 runs with the guard paragraph removed never offered a cross-facet OR once, and the checker does detect the real bad reply verbatim.

A scenario that passes on a codebase containing the bug is worse than no scenario. Deleted it; kept a deterministic test pinning the prompt paragraph, mutation-tested so that changing the sentence fails it. The docstring records the rule for anyone tempted to re-add one: *show it fails when the paragraph is removed, first.*

So: the bug is fixed and verified 3/3 on the reported query, and we **cannot** prove at the LLM level that it stays fixed. What we can guarantee is that the instruction cannot silently vanish.

## Also

402 unit tests, ruff + prettier clean. An adversarial pre-push review caught a real bug now fixed with a regression test: an `"ambiguous"` intent made `execute_query_model` short-circuit, reporting **every term as 0 studies** in the refusal payload — numbers the agent is instructed to quote to the user. Copilot caught three more (a false `reason` string, the same stale rule in the tool docstring and in `models.py`, a missing separator).

Follow-ups filed from manual testing: **#418** (chips render raw concept IDs), **#419** (pre-commit typecheck fails while the dev server runs), **#420** (the agent answers from a 5-study sample while implying it surveyed all results).

**Known limitation:** the invariant is enforced only inside `update_query`. `api.py` seeds `query_state` from the client's session and `/search/filter` never runs the check. Recoverable via `reset`; noted on #363.
