### PR TITLE
fix: typecheck fails while dev server is running (#419)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "postbuild": "next-sitemap --config next-sitemap.config.mjs",
     "start": "npx serve out",
     "lint": "eslint .",
-    "typecheck": "next typegen && tsc --noEmit",
+    "typecheck": "next typegen && tsc --noEmit -p tsconfig.typecheck.json",
     "check-format": "prettier --check .",
     "prepare": "husky",
     "test": "jest --watch",

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"]
+}

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,7 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "incremental": false
-  },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"]
 }


### PR DESCRIPTION
Closes #419.

## Problem

`next dev` writes `.next/dev/types/validator.ts`; `next typegen` (which `npm run typecheck` runs first) writes `.next/types/validator.ts`. Both declare `PagesPageConfig` at top level, and `tsconfig.json` includes both directories. So once a dev server has run, every commit fails:

```
.next/dev/types/validator.ts(7,6): error TS2300: Duplicate identifier 'PagesPageConfig'.
.next/types/validator.ts(7,6): error TS2300: Duplicate identifier 'PagesPageConfig'.
```

CI never sees this — no dev server there, so `.next/dev/types` never exists.

## Why not option 1 from the issue

The issue proposed dropping `.next/dev/types/**/*.ts` from `tsconfig.json`'s `include`. **That doesn't hold:** `next dev` rewrites `tsconfig.json` on startup and re-adds the entry (it also expands the arrays, so it dirties the file). The fix would silently revert itself the next time anyone ran the dev server.

Instead, `typecheck` now uses `tsconfig.typecheck.json`, which extends `tsconfig.json` and overrides `include` to take only `.next/types`. `tsconfig.json` is left exactly as Next.js wants it.

`incremental` is inherited from the base config, so the typecheck stays incremental — a warm run is ~1.5s, versus ~5.2s if it were disabled. The separate config name produces its own `tsconfig.typecheck.tsbuildinfo`, already covered by `*.tsbuildinfo` in `.gitignore`.

## What the dev-only directory actually contained

I diffed them. Four files each; `cache-life.d.ts` and `package.json` are byte-identical. The two that differ:

- `routes.d.ts` — the dev copy adds `"/_app" | "/_document" | "/_error"` to the `PageRoutes` union. These aren't navigable routes; the build copy is the more correct one. (Moot today: `typedRoutes` is off, so nothing consumes the union.)
- `validator.ts` — same structure, different relative import depth, plus three extra validation blocks for `_app`/`_document`/`_error`.

Those three files are still fully typechecked via the `**/*.tsx` include. What's lost is only the structural "conforms to `PagesPageConfig`" assertion on them. **No source file leaves the program** — 2293 files → 2290.

## Verification

With a real dev server's artifacts on disk:

- old command (`tsc --noEmit`) → TS2300, as reported
- `npm run typecheck` → passes, 5.5s cold / 1.7s warm
- full pre-commit hook (prettier + eslint + typecheck) → passes; both commits here were made with `.next/dev/types` present

I also drove `tsserver` directly over its stdio protocol to check the editor, since `tsc` ignores the `plugins: [{ name: "next" }]` language-service plugin entirely and therefore can't answer IDE questions. With the plugin confirmed loaded (`Enabling plugin next`), the editor's program and `pages/_app.tsx` semantic diagnostics are unchanged by this PR. A negative control (in-memory broken file) confirmed the probe reports errors when they exist.

Not covered: completions. If the `next` plugin ever sourced `href` autocomplete from `routes.d.ts`, that'd need a `completionInfo` probe — but `.next/types/routes.d.ts` still supplies the union either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)