### PR TITLE
feat: stage 0: ssg output-shape guardrail (lock in current blank-html baseline) (#426)

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -1,5 +1,10 @@
 name: Run checks
-on: [pull_request]
+# Also run on pushes to main: each PR is only checked against its own merge
+# ref, so the merged combination of PRs is otherwise never verified.
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 # Cancel superseded runs — the ssg-output job builds ~26.5k static pages, so
 # stacked pushes to a PR would otherwise queue full builds.
@@ -14,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          cache: "npm"
           node-version-file: ".nvmrc"
       # .nvmrc is the operative Node pin (deploy scripts + setup-node above);
       # assert package.json engines still mirrors it (#403).
@@ -38,6 +44,14 @@ jobs:
         with:
           cache: "npm"
           node-version-file: ".nvmrc"
+      # Restore Next's compiler/build cache (setup-node's npm cache only
+      # covers package downloads) — the full export takes ~16 minutes cold.
+      - uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
       - run: npm ci
       - run: npm run build:dev
       - run: npm run verify-ssg-output

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -1,6 +1,12 @@
 name: Run checks
 on: [pull_request]
 
+# Cancel superseded runs — the ssg-output job builds ~26.5k static pages, so
+# stacked pushes to a PR would otherwise queue full builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,3 +26,18 @@ jobs:
           cd catalog-build
           npm ci
           npx tsc --noEmit
+  # SSG output-shape guardrail: build the static export and assert on the
+  # emitted HTML. Every route currently ships a blank <div id="__next"> body;
+  # the guardrail locks that baseline in so each stage of the SSG restoration
+  # flips one expectation deliberately instead of regressing silently.
+  ssg-output:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          node-version-file: ".nvmrc"
+      - run: npm ci
+      - run: npm run build:dev
+      - run: npm run verify-ssg-output

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "husky",
     "test": "jest --watch",
     "test:e2e": "playwright test",
+    "verify-ssg-output": "esrun scripts/verify-ssg-output.ts",
     "build-ncpi-db": "esrun catalog-build/build-ncpi-catalog.ts",
     "update-anvil-source": "esrun catalog-build/update-anvil-source.ts",
     "update-bdc-source": "esrun catalog-build/update-bdc-source.ts",

--- a/scripts/verify-ssg-output.ts
+++ b/scripts/verify-ssg-output.ts
@@ -1,0 +1,188 @@
+/**
+ * SSG output-shape guardrail.
+ *
+ * Asserts on the HTML emitted by `next build` into `out/`, locking in the
+ * CURRENT output shape so the staged restoration of server-rendered HTML is
+ * verifiable. Today every route is statically exported with an empty
+ * `<div id="__next"></div>` because `pages/_app.tsx` gates the whole tree
+ * behind a client-side entities fetch — the failure mode is blank HTML, not a
+ * crash, so without these assertions a regression looks identical to success.
+ *
+ * The asymmetry encoded below is deliberate:
+ * - `/studies` is EXPECTED to remain a blank shell permanently — it is an
+ *   interactive table behind a client-side fetch. Do not "fix" it.
+ * - `/`, `/platforms` and `/research/studies/*` are blank only until the
+ *   `_app` entities gate is deleted, which flips them to server-rendered HTML.
+ *
+ * Each later stage flips exactly one expectation here:
+ * - studies list moves to client-side fetch: `/studies` HTML byte budget
+ *   multi-MB → small
+ * - `_app` entities gate deleted: `/`, `/platforms` and `/research/studies/*`
+ *   body → RENDERED
+ */
+import fsp from "fs/promises";
+import path from "path";
+
+const BODY_EXPECTATION = {
+  BLANK: "BLANK",
+  RENDERED: "RENDERED",
+} as const;
+
+type BodyExpectation = (typeof BODY_EXPECTATION)[keyof typeof BODY_EXPECTATION];
+
+interface RouteExpectation {
+  body: BodyExpectation;
+  comment: string;
+  maxBytes: number;
+  minBytes: number;
+  relPath: string;
+}
+
+interface StudyDetailTab {
+  label: string;
+  suffix: string;
+}
+
+const OUT_DIR = path.resolve(process.cwd(), "out");
+
+/**
+ * Marker emitted by the Next.js pages router around the app's rendered HTML.
+ * A blank page renders the open and close tags with nothing between them.
+ */
+const NEXT_ROOT_OPEN = '<div id="__next">';
+const NEXT_ROOT_BLANK = '<div id="__next"></div>';
+
+/**
+ * Byte budgets (see epic #425). The windows are categorical, not precise:
+ * blank shells are a few KB of head + `__NEXT_DATA__`; `/studies` bakes the
+ * full studies list (~17.3 MB today) into `__NEXT_DATA__`; `/platforms` bakes
+ * the platforms list (~0.5 MB). They are wide enough that routine catalog
+ * data refreshes never trip them, while still distinguishing "multi-MB baked
+ * payload" from "small shell" — the flip each later stage must make
+ * deliberately.
+ */
+const BLANK_SHELL_MAX_BYTES = 50_000;
+const PLATFORMS_HTML_MIN_BYTES = 200_000;
+const PLATFORMS_HTML_MAX_BYTES = 1_500_000;
+const STUDIES_HTML_MIN_BYTES = 10_000_000;
+const STUDIES_HTML_MAX_BYTES = 30_000_000;
+
+/**
+ * A known dbGaP id with variables and selected-publications subpages, used to
+ * spot-check the 8,832 prerendered study detail routes. If this study is ever
+ * dropped from the catalog, swap in any other id present in
+ * `catalog/ncpi-platform-studies.json`.
+ */
+const KNOWN_STUDY_ID = "phs000220";
+
+const STUDY_DETAIL_TABS: StudyDetailTab[] = [
+  { label: "overview", suffix: ".html" },
+  { label: "variables tab", suffix: "/variables.html" },
+  { label: "selected-publications tab", suffix: "/selected-publications.html" },
+];
+
+/**
+ * Builds the blank-shell expectation for one study detail tab.
+ * @param tab - Study detail tab to build the expectation for.
+ * @returns Route expectation for the tab.
+ */
+function buildStudyDetailExpectation(tab: StudyDetailTab): RouteExpectation {
+  return {
+    body: BODY_EXPECTATION.BLANK,
+    comment: `study detail ${tab.label} — blank until the _app gate is deleted`,
+    maxBytes: BLANK_SHELL_MAX_BYTES,
+    minBytes: 0,
+    relPath: `research/studies/${KNOWN_STUDY_ID}${tab.suffix}`,
+  };
+}
+
+const ROUTE_EXPECTATIONS: RouteExpectation[] = [
+  {
+    body: BODY_EXPECTATION.BLANK,
+    comment: "homepage — blank until the _app entities gate is deleted",
+    maxBytes: BLANK_SHELL_MAX_BYTES,
+    minBytes: 0,
+    relPath: "index.html",
+  },
+  {
+    body: BODY_EXPECTATION.BLANK,
+    comment:
+      "studies list — blank body is PERMANENT (interactive table, client fetch); " +
+      "the multi-MB __NEXT_DATA__ budget flips to small when the list moves to a client-side fetch",
+    maxBytes: STUDIES_HTML_MAX_BYTES,
+    minBytes: STUDIES_HTML_MIN_BYTES,
+    relPath: "studies.html",
+  },
+  {
+    body: BODY_EXPECTATION.BLANK,
+    comment:
+      "platforms list — control route; already small, blank until the _app gate is deleted",
+    maxBytes: PLATFORMS_HTML_MAX_BYTES,
+    minBytes: PLATFORMS_HTML_MIN_BYTES,
+    relPath: "platforms.html",
+  },
+  ...STUDY_DETAIL_TABS.map(buildStudyDetailExpectation),
+];
+
+/**
+ * Asserts a single route's emitted HTML matches its expectation.
+ * @param expectation - Route expectation to verify.
+ * @returns Error messages for the route; empty when the route passes.
+ */
+async function verifyRoute(expectation: RouteExpectation): Promise<string[]> {
+  const { body, comment, maxBytes, minBytes, relPath } = expectation;
+  const errors: string[] = [];
+  const filePath = path.join(OUT_DIR, relPath);
+  let html: Buffer;
+  try {
+    html = await fsp.readFile(filePath);
+  } catch (error) {
+    const { code } = error as NodeJS.ErrnoException;
+    return code === "ENOENT"
+      ? [`${relPath}: file not found (${comment})`]
+      : [`${relPath}: failed to read file — ${String(error)} (${comment})`];
+  }
+  if (html.length < minBytes || html.length > maxBytes) {
+    errors.push(
+      `${relPath}: ${html.length} bytes is outside budget [${minBytes}, ${maxBytes}] (${comment})`
+    );
+  }
+  if (!html.includes(NEXT_ROOT_OPEN)) {
+    errors.push(`${relPath}: no ${NEXT_ROOT_OPEN} root found (${comment})`);
+  } else if (body === BODY_EXPECTATION.BLANK) {
+    if (!html.includes(NEXT_ROOT_BLANK)) {
+      errors.push(
+        `${relPath}: expected a blank body (exactly ${NEXT_ROOT_BLANK}) but found rendered content (${comment})`
+      );
+    }
+  } else if (html.includes(NEXT_ROOT_BLANK)) {
+    errors.push(
+      `${relPath}: expected rendered body content but found ${NEXT_ROOT_BLANK} (${comment})`
+    );
+  }
+  return errors;
+}
+
+/**
+ * Verifies every route expectation against the build output and exits
+ * non-zero when any assertion fails.
+ * @returns Promise that resolves when verification completes.
+ */
+async function verifySsgOutput(): Promise<void> {
+  const errors = (
+    await Promise.all(ROUTE_EXPECTATIONS.map(verifyRoute))
+  ).flat();
+  if (errors.length > 0) {
+    console.error("SSG output-shape guardrail failed:");
+    for (const error of errors) console.error(`  - ${error}`);
+    process.exit(1);
+  }
+  console.log(
+    `SSG output-shape guardrail passed (${ROUTE_EXPECTATIONS.length} routes checked).`
+  );
+}
+
+verifySsgOutput().catch((error) => {
+  console.error("SSG output-shape guardrail crashed:", error);
+  process.exit(1);
+});

--- a/scripts/verify-ssg-output.ts
+++ b/scripts/verify-ssg-output.ts
@@ -47,10 +47,18 @@ const OUT_DIR = path.resolve(process.cwd(), "out");
 
 /**
  * Marker emitted by the Next.js pages router around the app's rendered HTML.
- * A blank page renders the open and close tags with nothing between them.
+ * A blank page renders nothing but whitespace or comments between the open
+ * tag and its closing `</div>`.
  */
 const NEXT_ROOT_OPEN = '<div id="__next">';
-const NEXT_ROOT_BLANK = '<div id="__next"></div>';
+
+/**
+ * How many bytes after the root div open tag are inspected when classifying
+ * the body as blank vs rendered, and how much of it is quoted in failure
+ * messages.
+ */
+const ROOT_WINDOW_BYTES = 512;
+const ROOT_SNIPPET_LENGTH = 80;
 
 /**
  * Byte budgets (see epic #425). The windows are categorical, not precise:
@@ -125,6 +133,16 @@ const ROUTE_EXPECTATIONS: RouteExpectation[] = [
 ];
 
 /**
+ * Classifies the content following the root div open tag as blank.
+ * @param rootContent - Content immediately following the root div open tag.
+ * @returns True when the root div holds nothing but whitespace or comments.
+ */
+function isBlankRootContent(rootContent: string): boolean {
+  const content = rootContent.replace(/^(\s|<!--[\s\S]*?-->)*/, "");
+  return content.startsWith("</div>");
+}
+
+/**
  * Asserts a single route's emitted HTML matches its expectation.
  * @param expectation - Route expectation to verify.
  * @returns Error messages for the route; empty when the route passes.
@@ -147,25 +165,34 @@ async function verifyRoute(expectation: RouteExpectation): Promise<string[]> {
       `${relPath}: ${html.length} bytes is outside budget [${minBytes}, ${maxBytes}] (${comment})`
     );
   }
-  if (!html.includes(NEXT_ROOT_OPEN)) {
+  const rootIndex = html.indexOf(NEXT_ROOT_OPEN);
+  if (rootIndex === -1) {
     errors.push(`${relPath}: no ${NEXT_ROOT_OPEN} root found (${comment})`);
-  } else if (body === BODY_EXPECTATION.BLANK) {
-    if (!html.includes(NEXT_ROOT_BLANK)) {
-      errors.push(
-        `${relPath}: expected a blank body (exactly ${NEXT_ROOT_BLANK}) but found rendered content (${comment})`
-      );
-    }
-  } else if (html.includes(NEXT_ROOT_BLANK)) {
+    return errors;
+  }
+  const contentStart = rootIndex + NEXT_ROOT_OPEN.length;
+  const rootContent = html
+    .subarray(contentStart, contentStart + ROOT_WINDOW_BYTES)
+    .toString("utf8");
+  const isBlank = isBlankRootContent(rootContent);
+  if (body === BODY_EXPECTATION.BLANK && !isBlank) {
+    const snippet = JSON.stringify(rootContent.slice(0, ROOT_SNIPPET_LENGTH));
     errors.push(
-      `${relPath}: expected rendered body content but found ${NEXT_ROOT_BLANK} (${comment})`
+      `${relPath}: expected a blank ${NEXT_ROOT_OPEN} body but found content starting with ${snippet} (${comment})`
+    );
+  } else if (body === BODY_EXPECTATION.RENDERED && isBlank) {
+    errors.push(
+      `${relPath}: expected rendered body content but the ${NEXT_ROOT_OPEN} root is blank (${comment})`
     );
   }
   return errors;
 }
 
 /**
- * Verifies every route expectation against the build output and exits
- * non-zero when any assertion fails.
+ * Verifies every route expectation against the build output and sets a
+ * non-zero exit code when any assertion fails. Uses `process.exitCode` rather
+ * than `process.exit()` so queued stderr writes flush before the process
+ * ends (stdio is asynchronous when piped, as in CI).
  * @returns Promise that resolves when verification completes.
  */
 async function verifySsgOutput(): Promise<void> {
@@ -175,7 +202,8 @@ async function verifySsgOutput(): Promise<void> {
   if (errors.length > 0) {
     console.error("SSG output-shape guardrail failed:");
     for (const error of errors) console.error(`  - ${error}`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   console.log(
     `SSG output-shape guardrail passed (${ROUTE_EXPECTATIONS.length} routes checked).`
@@ -184,5 +212,5 @@ async function verifySsgOutput(): Promise<void> {
 
 verifySsgOutput().catch((error) => {
   console.error("SSG output-shape guardrail crashed:", error);
-  process.exit(1);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary

Closes #426 — Stage 0 of epic #425.

Locks in the current SSG output shape so every later stage of the epic is verifiable. Today every route is statically exported with an empty `<div id="__next"></div>` because `pages/_app.tsx` gates the whole tree behind a client-side entities fetch — blank HTML, not a crash, so CI is green while the homepage renders nothing server-side. No behavior change.

## Changes

- **`scripts/verify-ssg-output.ts`** (`npm run verify-ssg-output`) — asserts over `out/` post-build:
  - blank `__next` body on `/`, `/studies`, `/platforms`, and the `phs000220` study detail pages (overview, variables, selected-publications)
  - categorical byte budgets: `studies.html` 10–30 MB (the baked `__NEXT_DATA__` payload — flips to small at stage 3a), `platforms.html` 200 KB–1.5 MB, 50 KB cap on blank shells
  - the asymmetry is documented in the file header: `/studies` stays a blank shell permanently (interactive table, client fetch); the rest flip to rendered HTML when the `_app` gate is deleted (stage 2)
- **`.github/workflows/run-checks.yml`** — new `ssg-output` job: `npm ci` → `npm run build:dev` → `npm run verify-ssg-output`; workflow-level `concurrency` with cancel-in-progress so stacked pushes don't queue full ~26.5k-page builds; npm cache on the new job.

## Deviations from the ticket

- The ticket's baseline table asserts `/platforms body > 0`, but on `main` its body is empty too — the `_app` gate blanks every route; "healthy" in the epic referred to its transfer size. The guardrail asserts the current truth (blank body + size budget) so it merges green; stage 2 flips it to rendered.
- Ticket numbers are kept out of the code comments except the required pointer at epic #425 on the byte-budget constants.

## Verification

- Fresh `npm run build:dev` passes the guardrail; tampering a built page correctly fails it (exit 1)
- Unit tests 150/150; lint, prettier, typecheck clean
- Note: this is the first time `next build` runs on a GitHub-hosted runner — watch this PR's `ssg-output` job runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)