### PR TITLE
feat: stage 3a: switch studies list to ss_fetch_cs_filtering (full json, no slimming) (#427)

### DIFF
--- a/app/utils/seedDatabase.ts
+++ b/app/utils/seedDatabase.ts
@@ -3,15 +3,28 @@ import { database } from "@databiosphere/findable-ui/lib/utils/database";
 import fsp from "fs/promises";
 
 /**
+ * Returns all entities for the given entity config at build time, seeding the
+ * in-memory database from the config's static-load file. Build-time code must
+ * read entities this way rather than through the entity service: with
+ * SS_FETCH_CS_FILTERING (apiPath set) the service resolves to API_CF, whose
+ * fetchAllEntities issues an HTTP request for the relative apiPath — which
+ * cannot work at build time.
+ * @param entityConfig - Entity config.
+ * @returns Entities from the seeded database.
+ */
+export async function getBuildTimeEntities(
+  entityConfig: EntityConfig
+): Promise<unknown[]> {
+  await seedDatabase(entityConfig);
+  return database.get().all(entityConfig.route);
+}
+
+/**
  * Seed database.
- * @param entityListType - Entity list type.
  * @param entityConfig - Entity config.
  */
-export async function seedDatabase(
-  entityListType: string,
-  entityConfig: EntityConfig
-): Promise<void> {
-  const { entityMapper, label, staticLoadFile } = entityConfig;
+export async function seedDatabase(entityConfig: EntityConfig): Promise<void> {
+  const { entityMapper, label, route, staticLoadFile } = entityConfig;
 
   if (!staticLoadFile) throw new Error(`No static file for ${label}`);
 
@@ -33,5 +46,5 @@ export async function seedDatabase(
     : Object.values(object);
 
   // Seed database.
-  database.get().seed(entityListType, entities);
+  database.get().seed(route, entities);
 }

--- a/app/utils/seedDatabase.ts
+++ b/app/utils/seedDatabase.ts
@@ -5,66 +5,101 @@ import path from "path";
 
 /**
  * Parsed-and-mapped entities per route, memoized for the lifetime of the
- * build worker. Reading, parsing and mapping the static-load file is the
- * expensive part of seeding (ncpi-platform-studies.json is ~24 MB and
- * getStaticProps invokes seedDatabase once per prerendered page); the seed
- * write itself stays unconditional — see seedDatabase.
+ * build worker. Reading, parsing and mapping the static-load file is
+ * expensive (ncpi-platform-studies.json is ~24 MB and getStaticProps runs
+ * once per prerendered page), so it happens once per route here and every
+ * build-time consumer reads from this cache.
  */
 const entitiesByRoute = new Map<string, unknown[]>();
 
 /**
- * Returns all entities for the given entity config at build time, seeding the
- * in-memory database from the config's static-load file. Build-time code must
- * read entities this way rather than through the entity service: with
- * SS_FETCH_CS_FILTERING (apiPath set) the service resolves to API_CF, whose
- * fetchAllEntities issues an HTTP request for the relative apiPath — which
- * cannot work at build time.
+ * Entity-by-id indexes per route, derived lazily from entitiesByRoute.
+ */
+const entityByIdByRoute = new Map<string, Map<string, unknown>>();
+
+/**
+ * Returns all entities for the given entity config at build time, loaded from
+ * the config's static-load file. Build-time code must read entities this way
+ * rather than through the entity service: with SS_FETCH_CS_FILTERING
+ * (apiPath set) the service resolves to API_CF, whose fetchAllEntities issues
+ * an HTTP request for the relative apiPath — which cannot work at build time.
  * @param entityConfig - Entity config.
- * @returns Entities from the seeded database.
+ * @returns Entities from the static-load file.
  */
 export async function getBuildTimeEntities(
   entityConfig: EntityConfig
 ): Promise<unknown[]> {
-  await seedDatabase(entityConfig);
-  return database.get().all(entityConfig.route);
+  return loadEntities(entityConfig);
 }
 
 /**
- * Seed database. The file read/parse/map is memoized per route, but the seed
- * write runs on EVERY call: other build-time code (the local seedDatabase in
- * pages/[entityListType]/index.tsx) seeds the same routes with UNMAPPED
- * entities, and build workers interleave pages — skipping the write when the
- * route "is already seeded" could leave the wrong shape in the database.
+ * Returns the entity with the given id for the given entity config at build
+ * time, loaded from the config's static-load file — see getBuildTimeEntities.
  * @param entityConfig - Entity config.
+ * @param entityId - Entity id.
+ * @returns Entity with the given id, or undefined when not found.
  */
-export async function seedDatabase(entityConfig: EntityConfig): Promise<void> {
+export async function getBuildTimeEntity(
+  entityConfig: EntityConfig,
+  entityId: string
+): Promise<unknown> {
+  const { getId, label, route } = entityConfig;
+  let entityById = entityByIdByRoute.get(route);
+  if (!entityById) {
+    if (!getId) throw new Error(`No getId function for ${label}`);
+    const entities = await loadEntities(entityConfig);
+    entityById = new Map(entities.map((entity) => [getId(entity), entity]));
+    entityByIdByRoute.set(route, entityById);
+  }
+  return entityById.get(entityId);
+}
+
+/**
+ * Reads, parses and maps the entity config's static-load file, memoized per
+ * route for the lifetime of the build worker.
+ * @param entityConfig - Entity config.
+ * @returns Entities from the static-load file.
+ */
+async function loadEntities(entityConfig: EntityConfig): Promise<unknown[]> {
   const { entityMapper, label, route, staticLoadFile } = entityConfig;
 
   if (!staticLoadFile) throw new Error(`No static file for ${label}`);
 
   let entities = entitiesByRoute.get(route);
+  if (entities) return entities;
 
-  if (!entities) {
-    // Read file.
-    const filePath = path.resolve(process.cwd(), staticLoadFile);
-    let fileContent;
-    try {
-      fileContent = await fsp.readFile(filePath, "utf8");
-    } catch {
-      throw new Error(`File not found: ${staticLoadFile}`);
-    }
-
-    // Parse file content.
-    const object = JSON.parse(fileContent);
-
-    // Map entities.
-    entities = entityMapper
-      ? Object.values(object).map(entityMapper)
-      : Object.values(object);
-
-    entitiesByRoute.set(route, entities);
+  // Read file.
+  const filePath = path.resolve(process.cwd(), staticLoadFile);
+  let fileContent;
+  try {
+    fileContent = await fsp.readFile(filePath, "utf8");
+  } catch {
+    throw new Error(`File not found: ${staticLoadFile}`);
   }
 
-  // Seed database.
-  database.get().seed(route, entities);
+  // Parse file content.
+  const object = JSON.parse(fileContent);
+
+  // Map entities.
+  entities = entityMapper
+    ? Object.values(object).map(entityMapper)
+    : Object.values(object);
+
+  entitiesByRoute.set(route, entities);
+  return entities;
+}
+
+/**
+ * Seed database. Required only where findable-ui's TSV entity service is the
+ * reader (CS_FETCH_CS_FILTERING detail fetches go through the service, which
+ * reads this database internally); our own build-time code reads the memoized
+ * cache via getBuildTimeEntities/getBuildTimeEntity instead. The seed write
+ * runs on every call — other build-time code (the local seedDatabase in
+ * pages/[entityListType]/index.tsx) seeds the same routes with UNMAPPED
+ * entities and build workers interleave pages, so a "skip if already seeded"
+ * guard could leave the wrong shape in the database.
+ * @param entityConfig - Entity config.
+ */
+export async function seedDatabase(entityConfig: EntityConfig): Promise<void> {
+  database.get().seed(entityConfig.route, await loadEntities(entityConfig));
 }

--- a/app/utils/seedDatabase.ts
+++ b/app/utils/seedDatabase.ts
@@ -1,6 +1,16 @@
 import { EntityConfig } from "@databiosphere/findable-ui/lib/config/entities";
 import { database } from "@databiosphere/findable-ui/lib/utils/database";
 import fsp from "fs/promises";
+import path from "path";
+
+/**
+ * Parsed-and-mapped entities per route, memoized for the lifetime of the
+ * build worker. Reading, parsing and mapping the static-load file is the
+ * expensive part of seeding (ncpi-platform-studies.json is ~24 MB and
+ * getStaticProps invokes seedDatabase once per prerendered page); the seed
+ * write itself stays unconditional — see seedDatabase.
+ */
+const entitiesByRoute = new Map<string, unknown[]>();
 
 /**
  * Returns all entities for the given entity config at build time, seeding the
@@ -20,7 +30,11 @@ export async function getBuildTimeEntities(
 }
 
 /**
- * Seed database.
+ * Seed database. The file read/parse/map is memoized per route, but the seed
+ * write runs on EVERY call: other build-time code (the local seedDatabase in
+ * pages/[entityListType]/index.tsx) seeds the same routes with UNMAPPED
+ * entities, and build workers interleave pages — skipping the write when the
+ * route "is already seeded" could leave the wrong shape in the database.
  * @param entityConfig - Entity config.
  */
 export async function seedDatabase(entityConfig: EntityConfig): Promise<void> {
@@ -28,22 +42,28 @@ export async function seedDatabase(entityConfig: EntityConfig): Promise<void> {
 
   if (!staticLoadFile) throw new Error(`No static file for ${label}`);
 
-  let fileContent;
+  let entities = entitiesByRoute.get(route);
 
-  // Read file.
-  try {
-    fileContent = await fsp.readFile(staticLoadFile, "utf8");
-  } catch {
-    throw new Error(`File not found: ${staticLoadFile}`);
+  if (!entities) {
+    // Read file.
+    const filePath = path.resolve(process.cwd(), staticLoadFile);
+    let fileContent;
+    try {
+      fileContent = await fsp.readFile(filePath, "utf8");
+    } catch {
+      throw new Error(`File not found: ${staticLoadFile}`);
+    }
+
+    // Parse file content.
+    const object = JSON.parse(fileContent);
+
+    // Map entities.
+    entities = entityMapper
+      ? Object.values(object).map(entityMapper)
+      : Object.values(object);
+
+    entitiesByRoute.set(route, entities);
   }
-
-  // Parse file content.
-  const object = JSON.parse(fileContent);
-
-  // Map entities.
-  const entities = entityMapper
-    ? Object.values(object).map(entityMapper)
-    : Object.values(object);
 
   // Seed database.
   database.get().seed(route, entities);

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -200,20 +200,18 @@ async function getEntities(
  * Fetches the entity for the given entity ID.
  * @param entityConfig - Entity config.
  * @param entityId - Entity ID.
- * @returns entity response.
+ * @returns entity response, or undefined when the entity is not found.
  */
 async function getEntity(
   entityConfig: EntityConfig,
   entityId: string
-): Promise<AzulEntityStaticResponse> {
+): Promise<AzulEntityStaticResponse | undefined> {
   // Server-side fetch, client-side filtering: read the build-time entity
   // cache directly — the entity service for this mode (API_CF) does not
   // implement fetchEntityDetail and would throw.
   if (entityConfig.exploreMode === EXPLORE_MODE.SS_FETCH_CS_FILTERING) {
-    return (await getBuildTimeEntity(
-      entityConfig,
-      entityId
-    )) as AzulEntityStaticResponse;
+    return (await getBuildTimeEntity(entityConfig, entityId)) as
+      AzulEntityStaticResponse | undefined;
   }
   const { fetchEntityDetail, path } = getEntityService(entityConfig, undefined);
   return await fetchEntityDetail(

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -21,11 +21,11 @@ import { EntityDetailView } from "@databiosphere/findable-ui/lib/views/EntityDet
 import { NCPICatalogStudy } from "app/apis/catalog/ncpi-catalog/common/entities";
 import { StudyJsonLd } from "app/components/Detail/components/StudyJsonLd/studyJsonLd";
 import { config } from "app/config/config";
+import { getBuildTimeEntities, seedDatabase } from "app/utils/seedDatabase";
 import { getStudyPageMeta } from "app/utils/studyTitles";
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
-import { readFile } from "../../app/utils/tsvParser";
 
 const setOfProcessedIds = new Set<string>();
 
@@ -67,38 +67,6 @@ const EntityDetailPage = (props: EntityDetailPageProps): JSX.Element => {
 };
 
 /**
- * Seed database.
- * @param entityListType - Entity list type.
- * @param entityConfig - Entity config.
- * @returns Promise<void>.
- */
-const seedDatabase = async function seedDatabase(
-  entityListType: string,
-  entityConfig: EntityConfig
-): Promise<void> {
-  const { entityMapper, label, staticLoadFile } = entityConfig;
-
-  if (!staticLoadFile) {
-    throw new Error(`staticLoadFile not found for entity entity ${label}`);
-  }
-
-  // Build database from configured TSV, if any.
-  const rawData = await readFile(staticLoadFile);
-
-  if (!rawData) {
-    throw new Error(`File ${staticLoadFile} not found for entity ${label}`);
-  }
-
-  const object = JSON.parse(rawData.toString());
-  const entities = entityMapper
-    ? Object.values(object).map(entityMapper)
-    : Object.values(object);
-
-  // Seed entities.
-  database.get().seed(entityListType, entities);
-};
-
-/**
  * getStaticPaths - return the list of paths to prerender for each entity type and its tabs.
  * @returns Promise<GetStaticPaths<PageUrl>>.
  */
@@ -111,15 +79,11 @@ export const getStaticPaths: GetStaticPaths<PageUrl> = async () => {
   const paths: StaticPath[] = [];
 
   for (const entityConfig of entities) {
-    const { exploreMode, route: entityListType } = entityConfig;
+    const { exploreMode } = entityConfig;
     // Process static paths.
     if (entityConfig.detail.staticLoad) {
-      // Client-side fetch, client-side filtering.
-      if (exploreMode === EXPLORE_MODE.CS_FETCH_CS_FILTERING) {
-        await seedDatabase(entityListType, entityConfig);
-        const entitiesResponse = await getEntities(entityConfig);
-        processEntityPaths(entityConfig, entitiesResponse, paths);
-      }
+      // Paths sourced from the build-time seeded database.
+      await processSeededEntityPaths(entityConfig, paths);
       // Server-side fetch, server-side filtering.
       if (exploreMode === EXPLORE_MODE.SS_FETCH_SS_FILTERING) {
         // Fetch catalogs and generate a list of catalogs associated with the default catalog.
@@ -220,7 +184,7 @@ function getCatalogs(
  * @param listParams - List params.
  * @returns entities response.
  */
-export async function getEntities(
+async function getEntities(
   entityConfig: EntityConfig,
   catalog?: string,
   listParams?: AzulListParams
@@ -239,6 +203,14 @@ async function getEntity(
   entityConfig: EntityConfig,
   entityId: string
 ): Promise<AzulEntityStaticResponse> {
+  // Server-side fetch, client-side filtering: read the build-time seeded
+  // database directly — the entity service for this mode (API_CF) does not
+  // implement fetchEntityDetail and would throw.
+  if (entityConfig.exploreMode === EXPLORE_MODE.SS_FETCH_CS_FILTERING) {
+    return database
+      .get()
+      .find(entityConfig.route, entityId) as AzulEntityStaticResponse;
+  }
   const { fetchEntityDetail, path } = getEntityService(entityConfig, undefined);
   return await fetchEntityDetail(
     entityId,
@@ -270,6 +242,19 @@ function getTabRoutes(tabs: BackPageTabConfig[]): string[] {
 }
 
 /**
+ * Returns true when the explore mode sources build-time entities from the
+ * seeded in-memory database (rather than a remote API).
+ * @param exploreMode - Explore mode.
+ * @returns True when the mode is backed by the seeded database.
+ */
+function isSeededExploreMode(exploreMode: EXPLORE_MODE): boolean {
+  return (
+    exploreMode === EXPLORE_MODE.CS_FETCH_CS_FILTERING ||
+    exploreMode === EXPLORE_MODE.SS_FETCH_CS_FILTERING
+  );
+}
+
+/**
  * Processes the static paths for the given entity response.
  * @param entityConfig - Entity config.
  * @param entitiesResponse - Entities response.
@@ -277,7 +262,7 @@ function getTabRoutes(tabs: BackPageTabConfig[]): string[] {
  */
 function processEntityPaths(
   entityConfig: EntityConfig,
-  entitiesResponse: AzulEntitiesResponse,
+  entitiesResponse: Pick<AzulEntitiesResponse, "hits">,
   paths: StaticPath[]
 ): void {
   const { detail, route: entityListType } = entityConfig;
@@ -324,13 +309,30 @@ async function processEntityProps(
   if (!staticLoad) return;
   // When the entity detail is to be fetched from API, we only do so for the first tab.
   if (exploreMode === EXPLORE_MODE.SS_FETCH_SS_FILTERING && entityTab) return;
-  if (exploreMode === EXPLORE_MODE.CS_FETCH_CS_FILTERING) {
-    // Seed database.
-    await seedDatabase(entityConfig.route, entityConfig);
+  if (isSeededExploreMode(exploreMode)) {
+    // Seed database; SS_FETCH_CS_FILTERING details are also read from the
+    // build-time database — see getEntity.
+    await seedDatabase(entityConfig);
   }
   // Fetch entity detail, either from database or API.
   const entityResponse = await getEntity(entityConfig, entityId);
   if (entityResponse) {
     props.data = entityResponse;
   }
+}
+
+/**
+ * Processes static paths for entities whose paths are sourced from the
+ * build-time seeded database: client-side fetch mode, and server-side fetch
+ * with client-side filtering — see getBuildTimeEntities.
+ * @param entityConfig - Entity config.
+ * @param paths - Static paths.
+ */
+async function processSeededEntityPaths(
+  entityConfig: EntityConfig,
+  paths: StaticPath[]
+): Promise<void> {
+  if (!isSeededExploreMode(entityConfig.exploreMode)) return;
+  const hits = await getBuildTimeEntities(entityConfig);
+  processEntityPaths(entityConfig, { hits }, paths);
 }

--- a/pages/[entityListType]/[...params].tsx
+++ b/pages/[entityListType]/[...params].tsx
@@ -16,12 +16,15 @@ import { getEntityConfig } from "@databiosphere/findable-ui/lib/config/utils";
 import { fetchCatalog } from "@databiosphere/findable-ui/lib/entity/api/service";
 import { getEntityService } from "@databiosphere/findable-ui/lib/hooks/useEntityService";
 import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
-import { database } from "@databiosphere/findable-ui/lib/utils/database";
 import { EntityDetailView } from "@databiosphere/findable-ui/lib/views/EntityDetailView/entityDetailView";
 import { NCPICatalogStudy } from "app/apis/catalog/ncpi-catalog/common/entities";
 import { StudyJsonLd } from "app/components/Detail/components/StudyJsonLd/studyJsonLd";
 import { config } from "app/config/config";
-import { getBuildTimeEntities, seedDatabase } from "app/utils/seedDatabase";
+import {
+  getBuildTimeEntities,
+  getBuildTimeEntity,
+  seedDatabase,
+} from "app/utils/seedDatabase";
 import { getStudyPageMeta } from "app/utils/studyTitles";
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
@@ -82,7 +85,7 @@ export const getStaticPaths: GetStaticPaths<PageUrl> = async () => {
     const { exploreMode } = entityConfig;
     // Process static paths.
     if (entityConfig.detail.staticLoad) {
-      // Paths sourced from the build-time seeded database.
+      // Paths sourced from the build-time entity cache.
       await processSeededEntityPaths(entityConfig, paths);
       // Server-side fetch, server-side filtering.
       if (exploreMode === EXPLORE_MODE.SS_FETCH_SS_FILTERING) {
@@ -203,13 +206,14 @@ async function getEntity(
   entityConfig: EntityConfig,
   entityId: string
 ): Promise<AzulEntityStaticResponse> {
-  // Server-side fetch, client-side filtering: read the build-time seeded
-  // database directly — the entity service for this mode (API_CF) does not
+  // Server-side fetch, client-side filtering: read the build-time entity
+  // cache directly — the entity service for this mode (API_CF) does not
   // implement fetchEntityDetail and would throw.
   if (entityConfig.exploreMode === EXPLORE_MODE.SS_FETCH_CS_FILTERING) {
-    return database
-      .get()
-      .find(entityConfig.route, entityId) as AzulEntityStaticResponse;
+    return (await getBuildTimeEntity(
+      entityConfig,
+      entityId
+    )) as AzulEntityStaticResponse;
   }
   const { fetchEntityDetail, path } = getEntityService(entityConfig, undefined);
   return await fetchEntityDetail(
@@ -239,19 +243,6 @@ function getSlugPath(slug: string[], slugIndex: number): string | undefined {
  */
 function getTabRoutes(tabs: BackPageTabConfig[]): string[] {
   return tabs.map(({ route }) => route) ?? [];
-}
-
-/**
- * Returns true when the explore mode sources build-time entities from the
- * seeded in-memory database (rather than a remote API).
- * @param exploreMode - Explore mode.
- * @returns True when the mode is backed by the seeded database.
- */
-function isSeededExploreMode(exploreMode: EXPLORE_MODE): boolean {
-  return (
-    exploreMode === EXPLORE_MODE.CS_FETCH_CS_FILTERING ||
-    exploreMode === EXPLORE_MODE.SS_FETCH_CS_FILTERING
-  );
 }
 
 /**
@@ -309,9 +300,10 @@ async function processEntityProps(
   if (!staticLoad) return;
   // When the entity detail is to be fetched from API, we only do so for the first tab.
   if (exploreMode === EXPLORE_MODE.SS_FETCH_SS_FILTERING && entityTab) return;
-  if (isSeededExploreMode(exploreMode)) {
-    // Seed database; SS_FETCH_CS_FILTERING details are also read from the
-    // build-time database — see getEntity.
+  if (exploreMode === EXPLORE_MODE.CS_FETCH_CS_FILTERING) {
+    // Seed database; this mode's detail fetch goes through the TSV entity
+    // service, which reads the database internally. SS_FETCH_CS_FILTERING
+    // details are read from the build-time entity cache — see getEntity.
     await seedDatabase(entityConfig);
   }
   // Fetch entity detail, either from database or API.
@@ -323,7 +315,7 @@ async function processEntityProps(
 
 /**
  * Processes static paths for entities whose paths are sourced from the
- * build-time seeded database: client-side fetch mode, and server-side fetch
+ * build-time entity cache: client-side fetch mode, and server-side fetch
  * with client-side filtering — see getBuildTimeEntities.
  * @param entityConfig - Entity config.
  * @param paths - Static paths.
@@ -332,7 +324,13 @@ async function processSeededEntityPaths(
   entityConfig: EntityConfig,
   paths: StaticPath[]
 ): Promise<void> {
-  if (!isSeededExploreMode(entityConfig.exploreMode)) return;
+  const { exploreMode } = entityConfig;
+  if (
+    exploreMode !== EXPLORE_MODE.CS_FETCH_CS_FILTERING &&
+    exploreMode !== EXPLORE_MODE.SS_FETCH_CS_FILTERING
+  ) {
+    return;
+  }
   const hits = await getBuildTimeEntities(entityConfig);
   processEntityPaths(entityConfig, { hits }, paths);
 }

--- a/pages/[entityListType]/index.tsx
+++ b/pages/[entityListType]/index.tsx
@@ -62,7 +62,19 @@ const IndexPage = ({
   ...props
 }: ListPageProps): JSX.Element => {
   if (!entityListType) return <></>;
-  return <ExploreView entityListType={entityListType} {...props} />;
+  // Key by entity type so switching list tabs remounts ExploreView. Both list
+  // routes render this same page component, so without the key React reuses
+  // the component instance and useEntityList's fetched response survives the
+  // switch; during the transition the explore state's tabValue lags the page
+  // config, and the stale response gets mapped with the other entity's
+  // mapper — crashing the list (e.g. studies ⇄ platforms).
+  return (
+    <ExploreView
+      key={entityListType}
+      entityListType={entityListType}
+      {...props}
+    />
+  );
 };
 
 /**

--- a/pages/research/[researchType]/[...studyParams].tsx
+++ b/pages/research/[researchType]/[...studyParams].tsx
@@ -8,12 +8,11 @@ import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";
 import { NCPICatalogStudy } from "../../../app/apis/catalog/ncpi-catalog/common/entities";
 import { config } from "../../../app/config/config";
-import { seedDatabase } from "../../../app/utils/seedDatabase";
+import { getBuildTimeEntities } from "../../../app/utils/seedDatabase";
 import { getStudyPageMeta } from "../../../app/utils/studyTitles";
 import { RESEARCH_TYPE } from "../../../app/views/ResearchView/artifact/types";
 import { StyledMain } from "../../../app/views/ResearchView/components/Main/main.styles";
 import { StudyDetailView } from "../../../app/views/StudyDetailView/studyDetailView";
-import { getEntities } from "../../[entityListType]/[...params]";
 
 interface Params extends ParsedUrlQuery {
   researchType: string;
@@ -38,11 +37,9 @@ export const getStaticPaths: GetStaticPaths<Params> = async () => {
   for (const entityConfig of config().entities) {
     if (entityConfig.route !== "studies") continue;
 
-    await seedDatabase(entityConfig.route, entityConfig);
+    const entities = await getBuildTimeEntities(entityConfig);
 
-    const entities = await getEntities(entityConfig);
-
-    for (const entity of entities.hits) {
+    for (const entity of entities) {
       const study = entity as NCPICatalogStudy;
 
       if (!study.dbGapId) continue;

--- a/scripts/verify-ssg-output.ts
+++ b/scripts/verify-ssg-output.ts
@@ -10,15 +10,18 @@
  *
  * The asymmetry encoded below is deliberate:
  * - `/studies` is EXPECTED to remain a blank shell permanently — it is an
- *   interactive table behind a client-side fetch. Do not "fix" it.
- * - `/`, `/platforms` and `/research/studies/*` are blank only until the
- *   `_app` entities gate is deleted, which flips them to server-rendered HTML.
+ *   interactive table behind a client-side fetch of its apiPath JSON. Do not
+ *   "fix" it.
+ * - `/studies/<id>` pages must keep baking the study into `__NEXT_DATA__`
+ *   (props.data feeds the detail view statically); `/research/studies/<id>`
+ *   pages carry no baked study — the view reads the workflows store.
+ * - `/`, `/platforms`, `/studies/<id>` and `/research/studies/<id>` are blank
+ *   only until the `_app` entities gate is deleted, which flips them to
+ *   server-rendered HTML.
  *
- * Each later stage flips exactly one expectation here:
- * - studies list moves to client-side fetch: `/studies` HTML byte budget
- *   multi-MB → small
- * - `_app` entities gate deleted: `/`, `/platforms` and `/research/studies/*`
- *   body → RENDERED
+ * The remaining stage flips one expectation here:
+ * - `_app` entities gate deleted: `/`, `/platforms`, `/studies/<id>` and
+ *   `/research/studies/<id>` body → RENDERED
  */
 import fsp from "fs/promises";
 import path from "path";
@@ -36,6 +39,13 @@ interface RouteExpectation {
   maxBytes: number;
   minBytes: number;
   relPath: string;
+}
+
+interface StudyDetailFamily {
+  comment: string;
+  maxBytes: number;
+  minBytes: number;
+  pathPrefix: string;
 }
 
 interface StudyDetailTab {
@@ -62,26 +72,63 @@ const ROOT_SNIPPET_LENGTH = 80;
 
 /**
  * Byte budgets (see epic #425). The windows are categorical, not precise:
- * blank shells are a few KB of head + `__NEXT_DATA__`; `/studies` bakes the
- * full studies list (~17.3 MB today) into `__NEXT_DATA__`; `/platforms` bakes
- * the platforms list (~0.5 MB). They are wide enough that routine catalog
- * data refreshes never trip them, while still distinguishing "multi-MB baked
- * payload" from "small shell" — the flip each later stage must make
- * deliberately.
+ * blank shells are a few KB of head + `__NEXT_DATA__`; `/studies` no longer
+ * bakes the studies list (fetched at runtime from its apiPath); `/studies/<id>`
+ * bakes one study (~24 KB) into `__NEXT_DATA__`; `/platforms` bakes the
+ * platforms list (~0.5 MB). They are wide enough that routine catalog data
+ * refreshes never trip them, while still distinguishing "baked payload" from
+ * "small shell" — any flip must be made deliberately.
  */
 const BLANK_SHELL_MAX_BYTES = 50_000;
 const PLATFORMS_HTML_MIN_BYTES = 200_000;
 const PLATFORMS_HTML_MAX_BYTES = 1_500_000;
-const STUDIES_HTML_MIN_BYTES = 10_000_000;
-const STUDIES_HTML_MAX_BYTES = 30_000_000;
+const STUDY_DETAIL_HTML_MIN_BYTES = 10_000;
+const STUDY_DETAIL_HTML_MAX_BYTES = 150_000;
+
+/**
+ * The studies list JSON served at runtime (the studies entity's apiPath,
+ * copied into the export by scripts/sync-api.sh). It is now the sole source
+ * of the studies list, so the export must contain it — a broken artifact
+ * pipeline would otherwise stay green while the deployed list fails its
+ * runtime fetch. The size window flips to small when the list JSON is
+ * slimmed (see epic #425).
+ */
+const LIST_ARTIFACT_REL_PATH = "api/ncpi-platform-studies.json";
+const LIST_ARTIFACT_MIN_BYTES = 10_000_000;
+const LIST_ARTIFACT_MAX_BYTES = 40_000_000;
 
 /**
  * A known dbGaP id with variables and selected-publications subpages, used to
- * spot-check the 8,832 prerendered study detail routes. If this study is ever
+ * spot-check both prerendered study detail route families (`/studies/<id>`
+ * and `/research/studies/<id>`, 8,832 paths each). If this study is ever
  * dropped from the catalog, swap in any other id present in
  * `catalog/ncpi-platform-studies.json`.
  */
 const KNOWN_STUDY_ID = "phs000220";
+
+/**
+ * The two prerendered study detail route families:
+ * - `/research/studies/<id>` carries no baked study — the view reads the
+ *   workflows store client-side — so it is a plain blank shell.
+ * - `/studies/<id>` is linked from the studies list and must keep baking the
+ *   study into `__NEXT_DATA__` (props.data feeds the detail view statically);
+ *   hence its minimum byte budget.
+ */
+const STUDY_DETAIL_FAMILIES: StudyDetailFamily[] = [
+  {
+    comment: "research study detail — blank until the _app gate is deleted",
+    maxBytes: BLANK_SHELL_MAX_BYTES,
+    minBytes: 0,
+    pathPrefix: "research/studies/",
+  },
+  {
+    comment:
+      "list-linked study detail — blank until the _app gate is deleted; must bake the study into __NEXT_DATA__",
+    maxBytes: STUDY_DETAIL_HTML_MAX_BYTES,
+    minBytes: STUDY_DETAIL_HTML_MIN_BYTES,
+    pathPrefix: "studies/",
+  },
+];
 
 const STUDY_DETAIL_TABS: StudyDetailTab[] = [
   { label: "overview", suffix: ".html" },
@@ -90,17 +137,21 @@ const STUDY_DETAIL_TABS: StudyDetailTab[] = [
 ];
 
 /**
- * Builds the blank-shell expectation for one study detail tab.
+ * Builds the expectation for one study detail tab of the given route family.
+ * @param family - Study detail route family to build the expectation for.
  * @param tab - Study detail tab to build the expectation for.
  * @returns Route expectation for the tab.
  */
-function buildStudyDetailExpectation(tab: StudyDetailTab): RouteExpectation {
+function buildStudyDetailExpectation(
+  family: StudyDetailFamily,
+  tab: StudyDetailTab
+): RouteExpectation {
   return {
     body: BODY_EXPECTATION.BLANK,
-    comment: `study detail ${tab.label} — blank until the _app gate is deleted`,
-    maxBytes: BLANK_SHELL_MAX_BYTES,
-    minBytes: 0,
-    relPath: `research/studies/${KNOWN_STUDY_ID}${tab.suffix}`,
+    comment: `${family.comment} (${tab.label})`,
+    maxBytes: family.maxBytes,
+    minBytes: family.minBytes,
+    relPath: `${family.pathPrefix}${KNOWN_STUDY_ID}${tab.suffix}`,
   };
 }
 
@@ -115,10 +166,10 @@ const ROUTE_EXPECTATIONS: RouteExpectation[] = [
   {
     body: BODY_EXPECTATION.BLANK,
     comment:
-      "studies list — blank body is PERMANENT (interactive table, client fetch); " +
-      "the multi-MB __NEXT_DATA__ budget flips to small when the list moves to a client-side fetch",
-    maxBytes: STUDIES_HTML_MAX_BYTES,
-    minBytes: STUDIES_HTML_MIN_BYTES,
+      "studies list — blank body is PERMANENT (interactive table, client-side " +
+      "fetch of the apiPath JSON); the list must NOT be baked into __NEXT_DATA__",
+    maxBytes: BLANK_SHELL_MAX_BYTES,
+    minBytes: 0,
     relPath: "studies.html",
   },
   {
@@ -129,7 +180,9 @@ const ROUTE_EXPECTATIONS: RouteExpectation[] = [
     minBytes: PLATFORMS_HTML_MIN_BYTES,
     relPath: "platforms.html",
   },
-  ...STUDY_DETAIL_TABS.map(buildStudyDetailExpectation),
+  ...STUDY_DETAIL_FAMILIES.flatMap((family) =>
+    STUDY_DETAIL_TABS.map((tab) => buildStudyDetailExpectation(family, tab))
+  ),
 ];
 
 /**
@@ -140,6 +193,32 @@ const ROUTE_EXPECTATIONS: RouteExpectation[] = [
 function isBlankRootContent(rootContent: string): boolean {
   const content = rootContent.replace(/^(\s|<!--[\s\S]*?-->)*/, "");
   return content.startsWith("</div>");
+}
+
+/**
+ * Asserts the runtime studies-list JSON artifact exists in the export within
+ * its byte budget.
+ * @returns Error messages for the artifact; empty when it passes.
+ */
+async function verifyListArtifact(): Promise<string[]> {
+  const filePath = path.join(OUT_DIR, LIST_ARTIFACT_REL_PATH);
+  let byteLength: number;
+  try {
+    byteLength = (await fsp.stat(filePath)).size;
+  } catch {
+    return [
+      `${LIST_ARTIFACT_REL_PATH}: missing — the studies list has no runtime data source`,
+    ];
+  }
+  if (
+    byteLength < LIST_ARTIFACT_MIN_BYTES ||
+    byteLength > LIST_ARTIFACT_MAX_BYTES
+  ) {
+    return [
+      `${LIST_ARTIFACT_REL_PATH}: ${byteLength} bytes is outside budget [${LIST_ARTIFACT_MIN_BYTES}, ${LIST_ARTIFACT_MAX_BYTES}]`,
+    ];
+  }
+  return [];
 }
 
 /**
@@ -197,7 +276,10 @@ async function verifyRoute(expectation: RouteExpectation): Promise<string[]> {
  */
 async function verifySsgOutput(): Promise<void> {
   const errors = (
-    await Promise.all(ROUTE_EXPECTATIONS.map(verifyRoute))
+    await Promise.all([
+      ...ROUTE_EXPECTATIONS.map(verifyRoute),
+      verifyListArtifact(),
+    ])
   ).flat();
   if (errors.length > 0) {
     console.error("SSG output-shape guardrail failed:");
@@ -206,7 +288,7 @@ async function verifySsgOutput(): Promise<void> {
     return;
   }
   console.log(
-    `SSG output-shape guardrail passed (${ROUTE_EXPECTATIONS.length} routes checked).`
+    `SSG output-shape guardrail passed (${ROUTE_EXPECTATIONS.length} routes + list artifact checked).`
   );
 }
 

--- a/site-config/ncpi-catalog/dev/config.ts
+++ b/site-config/ncpi-catalog/dev/config.ts
@@ -120,7 +120,10 @@ const config: SiteConfig = {
       size: "25",
       sort: "entryId",
     },
-    url: "https://service.nadove2.dev.singlecell.gi.ucsc.edu/",
+    // Base URL for entity-service fetches (the studies list apiPath). "/"
+    // resolves same-origin in every environment; this catalog has no Azul
+    // backend. (Replaces a vestigial single-cell explorer service URL.)
+    url: "/",
   },
   enableEntitiesView: true,
   entities: [platformsEntityConfig, studiesEntityConfig],

--- a/site-config/ncpi-catalog/dev/index/studiesEntityConfig.ts
+++ b/site-config/ncpi-catalog/dev/index/studiesEntityConfig.ts
@@ -12,6 +12,7 @@ import {
   NCPIStudyInputMapper,
 } from "../../../../app/apis/catalog/ncpi-catalog/common/utils";
 import * as C from "../../../../app/components";
+import { API } from "../../../../app/services/workflows/routes";
 import * as V from "../../../../app/viewModelBuilders/catalog/ncpi-catalog/common/viewModelBuilders";
 import {
   NCPI_CATALOG_CATEGORY_KEY,
@@ -27,6 +28,10 @@ import { variablesMainColumn } from "../detail/study/variablesMainColumn";
  * Entity config object responsible for config related to the /studies route.
  */
 export const studiesEntityConfig: EntityConfig<NCPICatalogStudy> = {
+  // Served at runtime to the studies list (SS_FETCH_CS_FILTERING); the same
+  // artifact also preloads the workflows store in `_app` — see
+  // app/services/workflows/routes.ts.
+  apiPath: API.studies,
   detail: {
     detailOverviews: ["Overview"],
     staticLoad: true,
@@ -51,7 +56,7 @@ export const studiesEntityConfig: EntityConfig<NCPICatalogStudy> = {
     top: top,
   },
   entityMapper: NCPIStudyInputMapper,
-  exploreMode: EXPLORE_MODE.CS_FETCH_CS_FILTERING,
+  exploreMode: EXPLORE_MODE.SS_FETCH_CS_FILTERING,
   getId: getStudyId,
   getTitle: getTitle,
   hideTabs: true,


### PR DESCRIPTION
## Summary

Closes #427 — Stage 3a of epic #425.

Stops baking the studies dataset into `/studies` HTML: the studies entity moves to `SS_FETCH_CS_FILTERING` and the list fetches the full, unmodified JSON from `apiPath` at runtime. `/studies` HTML drops **17,322,519 → 3,414 bytes**; total `/studies` transfer drops ~41 MB → ~24 MB. Slimming the JSON is #430.

## Changes

- **`site-config/.../studiesEntityConfig.ts`** — `exploreMode: SS_FETCH_CS_FILTERING` + `apiPath` (imported from the existing `API.studies` constant).
- **`site-config/.../config.ts`** — `dataSource.url: "/"` so the entity client resolves `apiPath` same-origin (landmine 3 below).
- **`app/utils/seedDatabase.ts`** — new `getBuildTimeEntities()` helper owning the build-time invariant: entities come from seeding the static-load file and reading the in-memory database, never through the entity service (landmine 1).
- **`pages/[entityListType]/[...params].tsx`** — build-time branches extended so `/studies/<id>` pages keep building with baked data in the new mode (landmine 2); local `seedDatabase` duplicate deleted in favour of the shared util.
- **`pages/[entityListType]/index.tsx`** — `ExploreView` keyed by entity type to work around a findable-ui tab-switch state bug (landmine 4).
- **`pages/research/[researchType]/[...studyParams].tsx`** — uses `getBuildTimeEntities()` instead of routing through `getEntityService`.
- **`scripts/verify-ssg-output.ts`** — `studies.html` budget flipped to blank-shell; new expectations for both study-detail route families (`/studies/<id>` must keep baking the study — 10 KB floor); new runtime-artifact check asserting `out/api/ncpi-platform-studies.json` exists within budget.

See the landmine comment on #427 for the four discoveries that expanded scope beyond the ticket's "no page change expected".

## Verification

- Full build: detail-page output byte-identical to baseline (pageProps diffed); 5,888 files in each detail family, unchanged.
- SSG guardrail passes (9 routes + list artifact).
- Browser hydration test on the production build: list renders 2,944 studies, JSON fetched same-origin, title links resolve, facet filtering works (2944→2574).
- Tab-switch regression test: 3 rounds of studies ⇄ platforms with no error boundary (crashed before the key fix; prod-parity confirmed).
- Unit tests 150/150; lint, prettier, typecheck clean.

## Known interim risks (accepted, resolved by later stages)

- The list JSON is 23.9 MB uncompressed until #430; findable-ui's ky client has a 20 s timeout, so very slow links may time out where the old baked-HTML approach couldn't.
- First visit fetches the JSON twice (`_app` entities gate + list fetch); the second is an ETag revalidation on real infra, and the double-fetch disappears at stage 2 (#429) when the gate is deleted.
- `useFetchEntity` can hit API_CF's unimplemented `fetchEntityDetail` on `/studies/<id>` if a crafted `?catalog=` param is present — a findable-ui limitation; the app never generates such URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)