### PR TITLE
fix: turn-aware history truncation to prevent orphaned tool-return 400 (#438)

### DIFF
--- a/backend/concept_search/api.py
+++ b/backend/concept_search/api.py
@@ -364,9 +364,10 @@ def _rate_limit_response(client_ip: str, query: str) -> JSONResponse:
     )
 
 
-# truncate_history keeps the first message plus the most recent N, so up to N+1
-# pydantic-ai messages are sent to the model (and retained in the stored history).
-_MAX_AGENT_HISTORY = 40
+# truncate_history keeps the first message (original intent) plus the most
+# recent N user turns, cutting only on turn boundaries so the retained history
+# never begins with an orphaned tool-return (which the model API 400s on).
+_MAX_AGENT_TURNS = 20
 _MAX_SESSION_MESSAGES = 50  # user/assistant text turns retained in the persisted transcript
 
 
@@ -405,9 +406,7 @@ async def search(
     deps = AgentDeps(
         index=index, query_state=state.query or QueryModel(), pending=list(state.pending)
     )
-    history = truncate_history(
-        deserialize_history(state.agent_message_history), _MAX_AGENT_HISTORY
-    )
+    history = truncate_history(deserialize_history(state.agent_message_history), _MAX_AGENT_TURNS)
 
     try:
         async with _pipeline_semaphore:
@@ -460,7 +459,7 @@ async def search(
     state.query = query_model
     state.pending = deps.pending
     state.agent_message_history = serialize_history(
-        truncate_history(new_history, _MAX_AGENT_HISTORY)
+        truncate_history(new_history, _MAX_AGENT_TURNS)
     )
     state.messages.append(ConversationMessage(content=request.query, role="user"))
     state.messages.append(ConversationMessage(content=reply, role="assistant"))

--- a/backend/concept_search/session_store.py
+++ b/backend/concept_search/session_store.py
@@ -23,6 +23,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
+from pydantic_ai.messages import UserPromptPart
 
 from .models import ConversationMessage, PendingChoice, QueryModel
 
@@ -48,27 +49,56 @@ class SessionState(BaseModel):
     query: QueryModel | None = None
 
 
-def truncate_history(messages: list, max_messages: int) -> list:
-    """Bound the agent message history sent to the model on long conversations.
+def _is_turn_start(message: Any) -> bool:
+    """True if *message* begins a user turn: a request carrying a user prompt.
 
-    Keeps the first message (the original intent) plus the most recent
-    ``max_messages`` entries.
+    Only a ``ModelRequest`` produced from a user message holds a
+    ``UserPromptPart``, so this marks the safe boundaries to cut a history
+    on — points where no ``tool-return`` is left without its ``tool-call``.
+
+    Args:
+        message: A pydantic-ai ``ModelMessage`` (or anything exposing ``parts``).
+
+    Returns:
+        Whether the message opens a new user turn.
+    """
+    return any(isinstance(part, UserPromptPart) for part in getattr(message, "parts", []))
+
+
+def truncate_history(messages: list, max_turns: int) -> list:
+    """Bound the agent message history to the most recent ``max_turns`` turns.
+
+    Keeps the first message (the original intent) plus every message from the
+    start of the ``max_turns``-th most recent user turn onward. Cutting on a
+    user-turn boundary guarantees the retained tail never begins with an
+    orphaned ``tool-return`` (a ``tool_result`` whose ``tool_use`` lived in a
+    dropped message), which the model API rejects with a 400. A raw
+    message-count slice cannot make that guarantee.
 
     Args:
         messages: The full message history, oldest first.
-        max_messages: Maximum number of recent messages to retain. Values <= 0
+        max_turns: Maximum number of recent user turns to retain. Values <= 0
             keep only the first message.
 
     Returns:
         The truncated history, or the original list if already within bounds.
     """
-    if max_messages <= 0:
-        return messages[:1]
-    # Result is first + last max_messages, i.e. up to max_messages + 1 entries;
-    # at or below that the history already fits, so return it unchanged.
-    if len(messages) <= max_messages + 1:
+    if not messages:
         return messages
-    return messages[:1] + messages[-max_messages:]
+    if max_turns <= 0:
+        return messages[:1]
+    turn_starts = [i for i, message in enumerate(messages) if _is_turn_start(message)]
+    # At or below max_turns boundaries the history already fits — return as-is.
+    if len(turn_starts) <= max_turns:
+        return messages
+    # Cut at the start of the max_turns-th most recent turn.
+    cut = turn_starts[-max_turns]
+    # cut == 1 would re-slice into an identical list; cut == 0 (unreachable — the
+    # check above guarantees a boundary before it) would duplicate the first
+    # message. Return as-is rather than do either.
+    if cut <= 1:
+        return messages
+    return messages[:1] + messages[cut:]
 
 
 @runtime_checkable

--- a/backend/tests/test_session_store.py
+++ b/backend/tests/test_session_store.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 import os
 
 import pytest
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
 
 from concept_search import session_store as session_store_module
 from concept_search.models import (
@@ -18,6 +27,7 @@ from concept_search.session_store import (
     InMemorySessionStore,
     SessionState,
     SessionStore,
+    _is_turn_start,
     get_session_store,
     truncate_history,
 )
@@ -93,22 +103,119 @@ async def test_pending_round_trips() -> None:
     assert got.pending == state.pending
 
 
-def test_truncate_history_keeps_first_and_recent() -> None:
-    """truncate_history keeps the first message plus the most recent N."""
-    messages = list(range(10))
-    assert truncate_history(messages, 3) == [0, 7, 8, 9]
+def _user_turn(text: str, *, system: bool = False) -> ModelRequest:
+    """A request that opens a user turn (optionally carrying the system prompt)."""
+    parts: list = [SystemPromptPart(content="you are a search assistant")] if system else []
+    parts.append(UserPromptPart(content=text))
+    return ModelRequest(parts=parts)
+
+
+def _tool_call(tool_call_id: str) -> ModelResponse:
+    """An assistant response that calls ``update_query``."""
+    return ModelResponse(
+        parts=[ToolCallPart(args={}, tool_call_id=tool_call_id, tool_name="update_query")]
+    )
+
+
+def _tool_return(tool_call_id: str) -> ModelRequest:
+    """The request delivering a tool result back to the model."""
+    return ModelRequest(
+        parts=[ToolReturnPart(content="ok", tool_call_id=tool_call_id, tool_name="update_query")]
+    )
+
+
+def _text_reply(text: str) -> ModelResponse:
+    """An assistant response with a plain text reply."""
+    return ModelResponse(parts=[TextPart(content=text)])
+
+
+def _turns(count: int) -> list:
+    """Build ``count`` full turns: user → tool-call → tool-return → text reply.
+
+    The first turn also carries the system prompt, mirroring pydantic-ai. Each
+    tool-call/tool-return pair shares a unique id so orphaning can be detected.
+    """
+    history: list = []
+    for i in range(count):
+        history.append(_user_turn(f"turn {i}", system=(i == 0)))
+        history.append(_tool_call(f"call-{i}"))
+        history.append(_tool_return(f"call-{i}"))
+        history.append(_text_reply(f"reply {i}"))
+    return history
+
+
+def _assert_valid_sequence(messages: list) -> None:
+    """Assert no tool-return precedes its tool-call — the API's 400 condition."""
+    seen_calls: set[str] = set()
+    for message in messages:
+        for part in message.parts:
+            if isinstance(part, ToolCallPart):
+                seen_calls.add(part.tool_call_id)
+            elif isinstance(part, ToolReturnPart):
+                assert part.tool_call_id in seen_calls, (
+                    f"orphaned tool-return {part.tool_call_id!r} with no preceding tool-call"
+                )
+
+
+def test_truncate_history_keeps_first_and_recent_turns() -> None:
+    """Truncation keeps the original intent plus the most recent ``max_turns`` turns."""
+    history = _turns(5)  # 20 messages, 5 user turns
+    result = truncate_history(history, 2)
+    # First message (system + original intent) is retained...
+    assert result[0] is history[0]
+    # ...and the tail resumes at a user-turn boundary (turn 3, index 12), so the
+    # kept turns are the original plus the last two.
+    assert result[1:] == history[12:]
+    assert _is_turn_start(result[1])
+    _assert_valid_sequence(result)
+
+
+def test_truncate_history_never_starts_tail_on_tool_return() -> None:
+    """A window that would open on a tool-return is cut back to a user boundary.
+
+    This is the #438 crash: a raw ``[-N:]`` slice can begin on a tool-return
+    whose tool-call was dropped, which the model API rejects with a 400.
+    """
+    history = _turns(6)
+    # A naive last-N slice landing mid-turn would begin on a tool-return.
+    naive_tail = history[-10:]
+    assert isinstance(naive_tail[0].parts[0], ToolReturnPart)
+    # Turn-aware truncation must not.
+    result = truncate_history(history, 3)
+    assert _is_turn_start(result[1])
+    _assert_valid_sequence(result)
+
+
+def test_truncate_history_replays_poisoned_session_shape() -> None:
+    """Regression for session 696f5758: long pair run truncates to a valid sequence."""
+    history = _turns(30)  # well over the retained window
+    result = truncate_history(history, 20)
+    assert result[0] is history[0]
+    assert _is_turn_start(result[1])
+    _assert_valid_sequence(result)
 
 
 def test_truncate_history_noop_within_bounds() -> None:
-    """truncate_history returns the list unchanged when within bounds."""
-    messages = [1, 2, 3]
-    assert truncate_history(messages, 5) == [1, 2, 3]
+    """Within ``max_turns`` boundaries the original list is returned unchanged."""
+    history = _turns(3)  # 3 user turns
+    assert truncate_history(history, 5) is history
 
 
 def test_truncate_history_noop_at_boundary() -> None:
-    """At first + max_messages total (len == max + 1), the original list is returned."""
-    messages = [0, 1, 2, 3, 4, 5]  # len 6 == max(5) + 1, already fits
-    assert truncate_history(messages, 5) is messages  # unchanged, not a copy
+    """At exactly ``max_turns`` turns the history already fits and is returned as-is."""
+    history = _turns(5)
+    assert truncate_history(history, 5) is history  # unchanged, not a copy
+
+
+def test_truncate_history_non_positive_keeps_only_first() -> None:
+    """``max_turns <= 0`` keeps only the original-intent message."""
+    history = _turns(4)
+    assert truncate_history(history, 0) == history[:1]
+
+
+def test_truncate_history_empty() -> None:
+    """An empty history is returned unchanged."""
+    assert truncate_history([], 20) == []
 
 
 @pytest.mark.asyncio()

--- a/backend/tests/test_session_store.py
+++ b/backend/tests/test_session_store.py
@@ -145,16 +145,24 @@ def _turns(count: int) -> list:
 
 
 def _assert_valid_sequence(messages: list) -> None:
-    """Assert no tool-return precedes its tool-call — the API's 400 condition."""
-    seen_calls: set[str] = set()
-    for message in messages:
-        for part in message.parts:
-            if isinstance(part, ToolCallPart):
-                seen_calls.add(part.tool_call_id)
-            elif isinstance(part, ToolReturnPart):
-                assert part.tool_call_id in seen_calls, (
-                    f"orphaned tool-return {part.tool_call_id!r} with no preceding tool-call"
-                )
+    """Assert every tool-return's tool-call sits in the immediately preceding message.
+
+    This is the exact Anthropic 400 condition: a ``tool_result`` must have its
+    ``tool_use`` in the *previous* message, not merely somewhere earlier.
+    """
+    for i, message in enumerate(messages):
+        returns = [p.tool_call_id for p in message.parts if isinstance(p, ToolReturnPart)]
+        if not returns:
+            continue
+        prev_calls = (
+            {p.tool_call_id for p in messages[i - 1].parts if isinstance(p, ToolCallPart)}
+            if i > 0
+            else set()
+        )
+        for tool_call_id in returns:
+            assert tool_call_id in prev_calls, (
+                f"tool-return {tool_call_id!r} has no matching tool-call in the previous message"
+            )
 
 
 def test_truncate_history_keeps_first_and_recent_turns() -> None:


### PR DESCRIPTION
Closes #438

## What changed

`truncate_history` (backend/concept_search/session_store.py) no longer slices the agent message history by raw message count. It now cuts on **user-turn boundaries**: keep the original-intent first message plus every message from the start of the `_MAX_AGENT_TURNS`-th most recent user turn onward. A new `_is_turn_start` helper identifies turn boundaries via `isinstance(part, UserPromptPart)`. The bound is reframed from messages to turns (`_MAX_AGENT_HISTORY = 40` → `_MAX_AGENT_TURNS = 20`), applied on both the read and write paths in `api.py`. Tests rewritten against real pydantic-ai message objects.

## Why

The old `messages[:1] + messages[-N:]` slice could leave the retained tail starting on a `tool-return` whose `tool-call` was in a dropped message. The Anthropic API rejects that sequence with a 400 (`unexpected tool_use_id ... must have a corresponding tool_use block`). Because the truncated history is **persisted**, every later turn in that session re-sent the corrupted history and re-failed until the 24h TTL evicted it — the session was poisoned, not just one turn. Confirmed live on dev; prod ran identical code. Cutting on a user-turn boundary makes an orphaned `tool-return` structurally impossible, because a turn boundary always follows a completed response (no open tool-call). Reframing to turns also makes the limit meaningful: the old 40-message cap was really ~7 turns since each turn spends 4–6 messages.

## Assumptions I made

- **20 turns** is the retained window (chosen with the maintainer). At ~5.5 KB/turn measured, that's ~110 KB per persisted session — comfortably under DynamoDB's 400 KB item cap (~3.6x margin), but ~2x the old ~50 KB. A per-turn **byte budget** for the unbounded worst case (one turn issuing many tool calls) is deliberately **not** in this PR — it belongs to the broader truncation-policy work in #380.
- The fix **prevents new poisoning; it does not repair sessions already corrupted by the old code**. A pre-existing poisoned session under the turn cap is returned unchanged and will keep 400ing until its 24h TTL evicts it. This is acceptable per #438's scope (TTL self-heals the backlog).
- `message[0]` is always the original system+user-prompt request in practice, so keeping `messages[:1]` never retains an orphan. General "validate/repair any invalid stored sequence" defense (e.g. against a corrupted or manually-edited store item whose head isn't a user prompt) is **out of scope** and left to #380.
- Scope is the agent history only. `_MAX_SESSION_MESSAGES` (the human-readable text transcript bound) is unchanged.

## How to verify

Definition of done from #438, mapped to steps:

1. **No truncated history can produce the orphaned-`tool_use_id` 400.**
   `cd backend && uv run python -m pytest tests/test_session_store.py -q` — 27 pass. Key cases: `test_truncate_history_never_starts_tail_on_tool_return` (a naive `[-N:]` window that would open on a tool-return is cut back to a user boundary) and `test_truncate_history_replays_poisoned_session_shape` (replays the session 696f5758 shape at the real 20-turn cap and asserts a valid sequence via `_assert_valid_sequence`).
2. **Bound expressed in turns, retains 20, applied on read and write.**
   Inspect `api.py` `search()`: both `truncate_history(deserialize_history(...), _MAX_AGENT_TURNS)` (read) and `serialize_history(truncate_history(new_history, _MAX_AGENT_TURNS))` (write) use the turn bound.
3. **End-to-end (optional, against dev):** hold a conversation past ~20 turns at `ncpi-data.dev.clevercanary.com/research/studies` and confirm turns keep succeeding (no soft-failure replies), then `make logs-dev` shows no `agent_error` with `tool_use_id`.
4. **Gate:** `cd backend && make format && make lint` clean; full suite `uv run python -m pytest tests/ -q` → 411 passed.

Gates #436 (prod deploy) per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)