### PR TITLE
fix: never commit intent=ambiguous with a non-empty query (#441)

### DIFF
--- a/backend/concept_search/CONVERSATION_PROMPT.md
+++ b/backend/concept_search/CONVERSATION_PROMPT.md
@@ -72,7 +72,13 @@ reveal concept IDs, studies, or values.
 Before acting each turn, consider:
 
 - **Intent**: is the user looking for studies or variables? (`study` |
-  `variable` | `ambiguous`). Set it via `update_query(intent=...)`.
+  `variable` | `ambiguous`). Set it via `update_query(intent=...)`. Once you
+  commit concrete facets, intent is `study` or `variable` — never `ambiguous`. A
+  committed query is a real search: reserve `ambiguous` for when you have
+  committed **no** facets and are asking the user to choose. Never report an
+  empty result on an ambiguous query as a real "0 results" or "impossible"
+  count — if you are genuinely unsure whether they want studies or variables,
+  ask, don't quote a number.
 - **Fresh, refine, or answering a question?** Use the conversation so far. A
   short reply like "the measurement one" is almost certainly answering your last
   disambiguation — resolve it and commit it.

--- a/backend/concept_search/conversation_agent.py
+++ b/backend/concept_search/conversation_agent.py
@@ -14,6 +14,7 @@ drives it is wired separately.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import re
 import threading
@@ -42,6 +43,8 @@ from .models import (
 )
 from .resolve_agent import run_resolve
 from .search_execution import execute_query_model
+
+logger = logging.getLogger(__name__)
 
 # Study-dict field backing each facet, for query_catalog aggregation.
 # (No SQL GROUP BY exists today — we aggregate from returned study dicts.)
@@ -433,6 +436,28 @@ def update_query(
     query_state.mentions = mentions
     if intent is not None:
         query_state.intent = intent
+
+    # A committed query is never intent-"ambiguous". "ambiguous" means "run no
+    # lookup; ask the user what they meant" (execute_query_model short-circuits to
+    # empty), which contradicts having concrete facets to search on. Left as-is,
+    # the empty result is narrated back as a real "0 results / impossible" answer.
+    # Coerce to the intent the committed facets imply so the summary, the persisted
+    # state, and the API response all report real counts: a query whose only
+    # committed filters are measurement concepts is a variable lookup; anything
+    # carrying a study-level facet is a study search.
+    if query_state.mentions and query_state.intent == "ambiguous":
+        committed = [m for m in query_state.mentions if m.values and not m.exclude]
+        coerced: Intent = (
+            "variable"
+            if committed and all(m.facet == Facet.MEASUREMENT for m in committed)
+            else "study"
+        )
+        logger.warning(
+            "coerced intent=ambiguous to %s on a committed query (%d mentions)",
+            coerced,
+            len(query_state.mentions),
+        )
+        query_state.intent = coerced
 
     # A term that was just committed or dropped is no longer an open choice.
     touched = {t.lower() for t in (remove or [])} | {i.original_text.lower() for i in (add or [])}

--- a/backend/concept_search/conversation_agent.py
+++ b/backend/concept_search/conversation_agent.py
@@ -439,17 +439,22 @@ def update_query(
 
     # A committed query is never intent-"ambiguous". "ambiguous" means "run no
     # lookup; ask the user what they meant" (execute_query_model short-circuits to
-    # empty), which contradicts having concrete facets to search on. Left as-is,
-    # the empty result is narrated back as a real "0 results / impossible" answer.
-    # Coerce to the intent the committed facets imply so the summary, the persisted
-    # state, and the API response all report real counts: a query whose only
-    # committed filters are measurement concepts is a variable lookup; anything
-    # carrying a study-level facet is a study search.
-    if query_state.mentions and query_state.intent == "ambiguous":
-        committed = [m for m in query_state.mentions if m.values and not m.exclude]
+    # empty), which contradicts having committed filter values to search on. Left
+    # as-is, the empty result is narrated back as a real "0 results / impossible"
+    # answer. A mention with no resolved values commits no filter, so gate on
+    # actual values, not on mere mention presence.
+    #
+    # Coerce to a concrete intent so the summary, the persisted state, and the API
+    # response all report real counts. This is a best-effort default for a
+    # mislabeled commit, not a claim about what execute_query_model can run: it
+    # handles variable intent with study-level constraints too, but the agent is
+    # meant to set that explicitly. The heuristic: committed includes that are all
+    # measurement concepts read as a variable lookup; otherwise default to study.
+    if query_state.intent == "ambiguous" and any(m.values for m in query_state.mentions):
+        includes = [m for m in query_state.mentions if m.values and not m.exclude]
         coerced: Intent = (
             "variable"
-            if committed and all(m.facet == Facet.MEASUREMENT for m in committed)
+            if includes and all(m.facet == Facet.MEASUREMENT for m in includes)
             else "study"
         )
         logger.warning(

--- a/backend/concept_search/eval_agent_conversation.py
+++ b/backend/concept_search/eval_agent_conversation.py
@@ -256,6 +256,17 @@ SCENARIOS: list[Scenario] = [
         lambda q, _r: len(_on(q, Facet.DATA_TYPE)) == 2 and _studies(q) == 118,
     ),
     Scenario(
+        # Terse "X and Y" phrasing must behave identically to the verbose form
+        # above (#441): the agent used to commit these mentions while tagging
+        # intent=ambiguous, so execution short-circuited to 0 and was narrated as
+        # an "impossible" combination. A committed query is never ambiguous.
+        "and-terse-datatype",
+        ["WGS and WXS"],
+        lambda q, _r: (
+            len(_on(q, Facet.DATA_TYPE)) == 2 and q.intent != "ambiguous" and _studies(q) == 118
+        ),
+    ),
+    Scenario(
         # platform is multi-valued too: 6 studies span two platforms, so an
         # intersection is a real answer. "both" makes the AND unambiguous.
         "and-platform-intersects",

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -176,6 +176,22 @@ def test_update_query_coerces_ambiguous_measurement_only_to_variable() -> None:
     assert out["intent"] == "variable"
 
 
+def test_update_query_leaves_ambiguous_when_no_values_committed() -> None:
+    """A value-less mention commits no filter, so intent stays ambiguous (#441).
+
+    "ambiguous" means "no committed facets — ask the user". A mention carrying no
+    resolved values has not committed a filter, so the coercion must not fire;
+    firing would force a misleading 0-result study search over an empty query.
+    """
+    ctx = _ctx(_FakeIndex())
+    update_query(
+        ctx,
+        add=[MentionInput(facet=Facet.FOCUS, original_text="x", values=[])],
+        intent="ambiguous",
+    )
+    assert ctx.deps.query_state.intent == "ambiguous"
+
+
 def test_update_query_reset_clears_filters_and_pending() -> None:
     """reset=True drops all prior filters and pending choices before applying."""
     ctx = _ctx(_FakeIndex())

--- a/backend/tests/test_conversation_agent.py
+++ b/backend/tests/test_conversation_agent.py
@@ -139,6 +139,43 @@ def test_update_query_sets_intent() -> None:
     assert ctx.deps.query_state.intent == "variable"
 
 
+def test_update_query_coerces_ambiguous_intent_on_committed_query() -> None:
+    """A committed query is never intent=ambiguous (#441).
+
+    Committing concrete facets with intent=ambiguous is a contradiction:
+    execute_query_model short-circuits ambiguous to an empty result, which the
+    agent then narrates as a false "0 results / impossible". The commit must
+    coerce intent to study so the summary reports the real count, not 0.
+    """
+    index = _FakeIndex(studies=[{"dbGapId": "phs1", "title": "S1", "focus": "X"}])
+    ctx = _ctx(index)
+    out = update_query(
+        ctx,
+        add=[MentionInput(facet=Facet.DATA_TYPE, original_text="WGS", values=["WGS"])],
+        intent="ambiguous",
+    )
+    assert ctx.deps.query_state.intent == "study"
+    assert out["intent"] == "study"
+    assert out["total_studies"] == 1
+
+
+def test_update_query_coerces_ambiguous_measurement_only_to_variable() -> None:
+    """A committed measurement-only ambiguous query coerces to variable, not study.
+
+    The intent a mislabeled query is coerced to must match the facets it holds: a
+    query whose only committed filter is a measurement concept is a variable
+    lookup, so coercing it to "study" would return the wrong result type (#441).
+    """
+    ctx = _ctx(_FakeIndex())
+    out = update_query(
+        ctx,
+        add=[MentionInput(facet=Facet.MEASUREMENT, original_text="glucose", values=["gluc"])],
+        intent="ambiguous",
+    )
+    assert ctx.deps.query_state.intent == "variable"
+    assert out["intent"] == "variable"
+
+
 def test_update_query_reset_clears_filters_and_pending() -> None:
     """reset=True drops all prior filters and pending choices before applying."""
     ctx = _ctx(_FakeIndex())


### PR DESCRIPTION
Closes #441

## What changed

`update_query` (the conversation agent's single commit path) now enforces that **a committed query is never `intent="ambiguous"`**. When the query has committed mentions but intent is `ambiguous`, it coerces to the intent the facets imply — `variable` when every committed non-excluded filter is a measurement concept, else `study` — logging a warning so we can still catch the agent producing the contradiction.

Also:
- **`CONVERSATION_PROMPT.md`** — reserves `ambiguous` for the uncommitted "ask the user which — studies or variables?" case, and forbids narrating an ambiguous empty result as a real "0 / impossible" count.
- **`eval_agent_conversation.py`** — adds an `and-terse-datatype` scenario (`"WGS and WXS"`) asserting 2 `dataType` mentions, non-ambiguous intent, and 118 studies.
- **`tests/test_conversation_agent.py`** — two deterministic unit tests pinning the coercion (dataType → study, measurement-only → variable).

## Why

`execute_query_model` short-circuits `intent="ambiguous"` to an empty result by design ("run no lookup; the caller asks the user"). But the agent sometimes committed real facets while tagging `ambiguous`, so the empty result was narrated as a false "0 results / impossible combination". The same intra-facet AND returned **0 or 118 depending only on phrasing**: terse `"WGS and WXS"` → 0 (ambiguous), verbose `"studies with both WGS and WXS data"` → 118 (study). WGS∧WXS is genuinely 118 (`dataType` is multi-valued). This re-triggered the exact failure mode #363/#417 fixed. The contradiction produced the false 0 in two places — the agent's own `_summarize` (so it narrated 0) and the API's `execute_query_model` (so `totalStudies` was 0) — both resolved by making the invariant hold at commit time.

## Assumptions I made

- **Fixed at the conversation agent, not the executor.** `execute_query_model`'s ambiguous short-circuit is correct for the genuine no-mentions "ask the user" case; the bug is only the committed-with-facets contradiction, so the guard lives at the single commit chokepoint (`update_query`). A `QueryModel` validator was rejected as too wide — it would also constrain the extract/resolve pipeline, which legitimately emits `ambiguous` during disambiguation.
- **Coercion default direction matters for result type.** An earlier draft always coerced to `study`; that would return studies (wrong result *type*) for a genuinely variable-intent query the agent mislabeled. The facet-aware default (measurement-only ⇒ `variable`) fixes that. This differs from `_count`'s flat ambiguous→study coercion, which is only about internal count numbers, not the user-facing result type.
- The one pre-existing eval miss, `disambig-reject-neither` (0/3), is tracked by open issue #377 and is orthogonal to this change (I edited only the intent bullet of the prompt, not pending-choice rejection).

## How to verify

Definition-of-done items from #441, mapped to steps:

1. **Terse phrasing returns 118.** In the app (or via `/search`), send `WGS and WXS`. It returns the same ~118 studies as `studies with both WGS and WXS data`, not "0 / impossible". The `and-terse-datatype` eval scenario asserts this (`cd backend && uv run python -m concept_search.eval_agent_conversation`, runs 3× with majority vote — passed 3/3 locally).
2. **No query is committed with `intent=ambiguous` + non-empty mentions.** `cd backend && uv run python -m pytest tests/test_conversation_agent.py -q` — `test_update_query_coerces_ambiguous_intent_on_committed_query` (dataType → study) and `test_update_query_coerces_ambiguous_measurement_only_to_variable` (measurement → variable) both pass.
3. **Eval/reproduction case with repeats.** Covered by item 1's scenario (REPEATS=3, majority vote).

Also green: full backend suite `uv run python -m pytest tests/ -q` (413 passed), `make lint`, `make format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)