### PR TITLE
chore: ignore coverage/ in ESLint config (#446)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ const config = [
       "analytics/**",
       "catalog/**",
       "catalog-build/**",
+      "coverage/**",
       ".gitlab/**",
       "next-env.d.ts",
       "next.config.mjs",


### PR DESCRIPTION
Closes #446

## What changed

Added `"coverage/**"` to the `ignores` array in `eslint.config.mjs`, alongside the other generated/vendor directory ignores (`out/**`, `.next/**`, `catalog/**`, `catalog-build/**`).

## Why

The pre-commit hook runs `eslint .`, which lints a generated `coverage/` directory whenever one is present locally (jest coverage output: `coverage/lcov-report/*.js`, `clover.xml`, `coverage-final.json`). `coverage/` is gitignored — so it never enters a commit — but it was not in the ESLint ignore list, so `eslint .` errored on its generated JS (`no-unlimited-disable`, `require-description`, …) and blocked commits until the directory was manually deleted. Any `npx jest --coverage` run leaves the directory behind; this was hit repeatedly while working on #441.

## Assumptions I made

- `coverage/**` is the correct glob for the flat-config ignore block — it matches the `catalog/**`/`catalog-build/**` sibling style already in the array, and `coverage/` is the conventional jest/istanbul output path.
- No override config in `eslint.config.mjs` targets `coverage/` (checked), so ignoring it removes lint errors without silencing any intended rule on real source.

## How to verify

Definition-of-done from #446:

1. Generate the directory: `npx jest --coverage` (creates `coverage/lcov-report/*.js`).
2. `npm run lint` → passes with **0 errors** (only the 5 pre-existing `sonarjs/todo-tag` warnings in untouched files). Before this change it reported 9 errors from `coverage/lcov-report/*.js`.
3. The pre-commit `eslint .` hook no longer fails while a `coverage/` directory is present.
4. Non-ignored source is still linted (the change adds one ignore glob; no rules are disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)